### PR TITLE
Fixed #61

### DIFF
--- a/src/TAO/API/build.cpp
+++ b/src/TAO/API/build.cpp
@@ -672,11 +672,11 @@ namespace TAO::API
 
             /* Extract the supply parameter */
             const uint64_t nSupply  =
-                ExtractInteger<uint64_t>(jParams, "supply");
+                ExtractNumber<uint64_t>(jParams, "supply");
 
             /* Check for nDecimals parameter. */
             const uint8_t nDecimals =
-                ExtractInteger<uint64_t>(jParams, "decimals", 2, convert::MAX_DIGITS); //2, 8: default of 2 decimals, max of 8
+                ExtractNumber<uint64_t>(jParams, "decimals", 2, convert::MAX_DIGITS); //2, 8: default of 2 decimals, max of 8
 
             /* Sanitize the supply/decimals combination for uint64 overflow */
             const uint64_t nCoinFigures = math::pow(10, nDecimals);

--- a/src/TAO/API/commands/finance/burn.cpp
+++ b/src/TAO/API/commands/finance/burn.cpp
@@ -60,7 +60,7 @@ namespace TAO::API
             throw Exception(-69, "Insufficient funds");
 
         /* The optional payment reference */
-        const uint64_t nReference = ExtractInteger<uint64_t>(jParams, "reference", 0); //0: as our default parameter
+        const uint64_t nReference = ExtractNumber<uint64_t>(jParams, "reference", 0); //0: as our default parameter
 
         /* Submit the payload object. */
         std::vector<TAO::Operation::Contract> vContracts(1);

--- a/src/TAO/API/commands/finance/debit.cpp
+++ b/src/TAO/API/commands/finance/debit.cpp
@@ -371,7 +371,7 @@ namespace TAO::API
                     }
 
                     /* The optional payment reference */
-                    const uint64_t nReference = ExtractInteger<uint64_t>(jRecipient, "reference", 0); //0: default reference of 0
+                    const uint64_t nReference = ExtractNumber<uint64_t>(jRecipient, "reference", 0); //0: default reference of 0
 
                     /* Submit the payload object. */
                     TAO::Operation::Contract tContract;

--- a/src/TAO/API/commands/invoices/create.cpp
+++ b/src/TAO/API/commands/invoices/create.cpp
@@ -112,8 +112,8 @@ namespace TAO::API
                 ExtractAmount((*it), nDigits);
 
             /* The item number of units */
-            const uint64_t nUnits =
-                ExtractInteger<uint64_t>((*it), "units");
+            const double nUnits =
+                ExtractNumber<double>((*it), "units");
 
             /* Rebuild our JSON to use correct formatting. */
             const encoding::json jItem =

--- a/src/TAO/API/commands/ledger/get-block-hash.cpp
+++ b/src/TAO/API/commands/ledger/get-block-hash.cpp
@@ -42,7 +42,7 @@ namespace TAO::API
 
         /* Convert the incoming height string to an int*/
         const uint32_t nHeight =
-            ExtractInteger<uint32_t>(jParams, "height", TAO::Ledger::ChainState::nBestHeight.load());
+            ExtractNumber<uint32_t>(jParams, "height", TAO::Ledger::ChainState::nBestHeight.load());
 
         /* Read the block state from the the ledger DB using the height index */
         TAO::Ledger::BlockState tBlock;

--- a/src/TAO/API/commands/ledger/get-block.cpp
+++ b/src/TAO/API/commands/ledger/get-block.cpp
@@ -38,7 +38,7 @@ namespace TAO::API
 
             /* Convert the incoming height string to an int*/
             const uint32_t nHeight =
-                ExtractInteger<uint32_t>(jParams, "height");
+                ExtractNumber<uint32_t>(jParams, "height");
 
             /* Check that the requested height is within our chain range*/
             if(nHeight > TAO::Ledger::ChainState::nBestHeight.load())

--- a/src/TAO/API/commands/ledger/list-blocks.cpp
+++ b/src/TAO/API/commands/ledger/list-blocks.cpp
@@ -59,7 +59,7 @@ namespace TAO::API
 
             /* Convert the incoming height string to an int*/
             const uint32_t nHeight =
-                ExtractInteger<uint32_t>(jParams, "height") + (strOrder == "desc" ? -nOffset : nOffset);
+                ExtractNumber<uint32_t>(jParams, "height") + (strOrder == "desc" ? -nOffset : nOffset);
 
             /* Check that the requested height is within our chain range*/
             if(nHeight > TAO::Ledger::ChainState::nBestHeight.load())

--- a/src/TAO/API/commands/templates/create.cpp
+++ b/src/TAO/API/commands/templates/create.cpp
@@ -127,7 +127,7 @@ namespace TAO::API
 
             /* If the caller specifies a maxlength then use this to set the size of the string */
             const uint64_t nMaxLength =
-                ExtractInteger<uint64_t>(jParams, "maxlength", ((strPayload.size() / 128) + 1) * 128, 1000); //128 bytes default padding
+                ExtractNumber<uint64_t>(jParams, "maxlength", ((strPayload.size() / 128) + 1) * 128, 1000); //128 bytes default padding
 
             /* Check for minimum ranges. */
             if(nMaxLength < strPayload.size())
@@ -229,7 +229,7 @@ namespace TAO::API
                 {
                     /* If the caller specifies a maxlength then use this to set the size of the string */
                     const uint64_t nMaxLength =
-                        ExtractInteger<uint64_t>(jParams, "maxlength", ((strPayload.size() / 64) + 1) * 64, 1000); //64 bytes default padding
+                        ExtractNumber<uint64_t>(jParams, "maxlength", ((strPayload.size() / 64) + 1) * 64, 1000); //64 bytes default padding
 
                     /* Check for minimum ranges. */
                     if(nMaxLength < strPayload.size())
@@ -325,19 +325,19 @@ namespace TAO::API
 
                 /* Handle for 8-bit unsigned int. */
                 if(strType == "uint8")
-                    tPayload << uint8_t(TAO::Register::TYPES::UINT8_T)   << ExtractInteger<uint8_t>((*it), "value");
+                    tPayload << uint8_t(TAO::Register::TYPES::UINT8_T)   << ExtractNumber<uint8_t>((*it), "value");
 
                 /* Handle for 16-bit unsigned int. */
                 if(strType == "uint16")
-                    tPayload << uint8_t(TAO::Register::TYPES::UINT16_T)  << ExtractInteger<uint16_t>((*it), "value");
+                    tPayload << uint8_t(TAO::Register::TYPES::UINT16_T)  << ExtractNumber<uint16_t>((*it), "value");
 
                 /* Handle for 32-bit unsigned int. */
                 if(strType == "uint32")
-                    tPayload << uint8_t(TAO::Register::TYPES::UINT32_T)  << ExtractInteger<uint32_t>((*it), "value");
+                    tPayload << uint8_t(TAO::Register::TYPES::UINT32_T)  << ExtractNumber<uint32_t>((*it), "value");
 
                 /* Handle for 64-bit unsigned int. */
                 if(strType == "uint64")
-                    tPayload << uint8_t(TAO::Register::TYPES::UINT64_T)  << ExtractInteger<uint64_t>((*it), "value");
+                    tPayload << uint8_t(TAO::Register::TYPES::UINT64_T)  << ExtractNumber<uint64_t>((*it), "value");
 
                 /* Handle for 256-bit unsigned int. */
                 if(strType == "uint256")
@@ -372,7 +372,7 @@ namespace TAO::API
                     {
                         /* If the caller specifies a maxlength then use this to set the size of the string */
                         const uint64_t nMaxLength =
-                            ExtractInteger<uint64_t>((*it), "maxlength", ((strPayload.size() / 64) + 1) * 64, 1000);
+                            ExtractNumber<uint64_t>((*it), "maxlength", ((strPayload.size() / 64) + 1) * 64, 1000);
 
                         /* Check for minimum ranges. */
                         if(nMaxLength < strPayload.size())

--- a/src/TAO/API/commands/templates/update.cpp
+++ b/src/TAO/API/commands/templates/update.cpp
@@ -234,19 +234,19 @@ namespace TAO::API
 
                 /* Handle for 8-bit unsigned int. */
                 if(nFieldType == TAO::Register::TYPES::UINT8_T)
-                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT8_T) << ExtractInteger<uint8_t>(jParams, strField);
+                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT8_T) << ExtractNumber<uint8_t>(jParams, strField);
 
                 /* Handle for 16-bit unsigned int. */
                 if(nFieldType == TAO::Register::TYPES::UINT16_T)
-                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT16_T) << ExtractInteger<uint16_t>(jParams, strField);
+                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT16_T) << ExtractNumber<uint16_t>(jParams, strField);
 
                 /* Handle for 32-bit unsigned int. */
                 if(nFieldType == TAO::Register::TYPES::UINT32_T)
-                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT32_T) << ExtractInteger<uint32_t>(jParams, strField);
+                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT32_T) << ExtractNumber<uint32_t>(jParams, strField);
 
                 /* Handle for 64-bit unsigned int. */
                 if(nFieldType == TAO::Register::TYPES::UINT64_T)
-                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT64_T) << ExtractInteger<uint64_t>(jParams, strField);
+                    ssPayload << uint8_t(TAO::Operation::OP::TYPES::UINT64_T) << ExtractNumber<uint64_t>(jParams, strField);
 
                 /* Handle for 256-bit unsigned int. */
                 if(nFieldType == TAO::Register::TYPES::UINT256_T)

--- a/src/TAO/API/conditions.cpp
+++ b/src/TAO/API/conditions.cpp
@@ -160,7 +160,7 @@ namespace TAO::API
         using namespace TAO::Operation;
 
         /* The optional expiration time */
-        const uint64_t nExpires = ExtractInteger<uint64_t>(params, "expires", 604800);
+        const uint64_t nExpires = ExtractNumber<uint64_t>(params, "expires", 604800);
 
         /* Check if there is an expiry set for the contract */
         if(nExpires > 0)

--- a/src/TAO/API/include/extract.h
+++ b/src/TAO/API/include/extract.h
@@ -311,22 +311,22 @@ namespace TAO::API
     }
 
 
-    /** ExtractInteger
+    /** ExtractNumber
      *
-     *  Extracts an integer value from given input parameters.
+     *  Extracts an number value from given input parameters.
      *
      *  @param[in] jParams The parameters that contain requesting value.
      *  @param[in] strKey The key that we are checking parameters for.
      *  @param[in] fRequired Determines if given parameter is required.
      *  @param[in] nLimit The numeric limits to bound this type to, that may be less than type's value.
      *
-     *  @return The extracted integer value.
+     *  @return The extracted number value.
      *
      **/
     template<typename Type>
-    Type ExtractInteger(const encoding::json& jParams, const std::string& strKey,
+    Type ExtractNumber(const encoding::json& jParams, const std::string& strKey,
                         const Type nDefault = std::numeric_limits<Type>::max(),
-                        const uint64_t nLimit = std::numeric_limits<Type>::max())
+                        const Type nLimit = std::numeric_limits<Type>::max())
     {
         /* Check for missing parameter. */
         if(jParams.find(strKey) != jParams.end())
@@ -335,14 +335,20 @@ namespace TAO::API
             try
             {
                 /* Build our return value. */
-                uint64_t nRet = 0;
+                Type nRet = 0;
 
                 /* Convert to value if in string form. */
                 if(jParams[strKey].is_string())
-                    nRet = std::stoull(jParams[strKey].get<std::string>());
-
-                /* Grab value regularly if it is integer. */
-                else if(jParams[strKey].is_number_integer())
+                {
+                    /* Check if templated type is an intergral. */
+                    if (std::is_integral_v<Type>)
+                        nRet = std::stoull(jParams[strKey].get<std::string>());
+                    /* Default to double. */
+                    else
+                        nRet = std::stod(jParams[strKey].get<std::string>());
+                }
+                /*Grab regularly if number. */
+                else if(jParams[strKey].is_number())
                     nRet = jParams[strKey].get<Type>();
 
                 /* Otherwise we have an invalid parameter. */


### PR DESCRIPTION
This is my solution for the issue found in #61 . The problem is that units was being extracted as an int but this restriction was not enforced by the API. In my opinion there is no reason why to have this limit, and a fraction of a unit should be allowed. 

I have renamed `ExtractInteger` to `ExtractNumber` which is templated to allow for both ints and doubles. I felt having 2 classes with almost identical code was not efficient. 

It might also be a good idea to then limit the units param to not be less than the number of digits of the supplied token. 

As this is my first major change to the LLL please provide feedback on if I have made a mistake in code or style. 
