### PR TITLE
docs: API/build typos and JSON formatting

### DIFF
--- a/docs/API/COMMANDS/FINANCE.MD
+++ b/docs/API/COMMANDS/FINANCE.MD
@@ -79,11 +79,11 @@ The following verbs are currently supported by this API command-set:
 
 The following commands are direct endpoints and thus do not support the above `verb` and `noun` structure available above.
 
-[`get/balances`](#get/balance)      
+[`get/balances`](#get/balances)      
 [`get/stakeinfo`](#get/stakeinfo)   
 [`set/stake`](#set/stake)  
 [`void/transaction`](#void/transaction)   
-[`migrate/accounts`](#migrate/account)   
+[`migrate/accounts`](#migrate/accounts)   
 
 Direct endpoints support filters and operators.
 
@@ -103,7 +103,7 @@ The following parameters can be used to apply **sorting** and **filtering** to t
 
 `sort`: The column or field-name to apply the sorting logic to. This parameter supports moving up levels of JSON keys by using `.`, such as `sort=json.date` would apply a sort to a nested JSON object:
 
-```
+```json
 {
     "modified": 1621782289,
     "json": {
@@ -170,7 +170,7 @@ This command does not support the `any` or `all` nouns.
 
 `address` : The register address for this  account. The address (or name that hashes to this address) is needed when creating crediting or debiting the account.
 
-```
+```json
 {
     "success": true,
     "address": "8ESvYizqdApiuKEBjZMF1hnB8asDqECaDwAstcH3UtJ4Z6ceCn2",
@@ -203,6 +203,6 @@ This command supports the `any` wildcard noun.
 
 `txid` : The ID (hash) of the transaction that includes the account creation.
 
-`address` : The register address for this  account. The address (or name that hashes to this address) is needed when creating crediting or debiting the account.
+`address` : The register address for this account. The address (or name that hashes to this address) is needed when creating crediting or debiting the account.
 
 -----------------------------------

--- a/docs/API/COMMANDS/LEDGER.MD
+++ b/docs/API/COMMANDS/LEDGER.MD
@@ -2,7 +2,7 @@
 -----------------------------------
 The Ledger API provides users with access to data held by the ledger such as blocks and transactions.
 
-**Info:** Retrieving block data by height is only possible if the core has been configured with --indexheight=1.
+**Info:** Retrieving block data by height is only possible if the core has been configured with `--indexheight=1`.
 
 ## `Direct Endpoints`
 
@@ -37,7 +37,7 @@ ledger/get/blockhash
 
 #### Return value JSON object:
 
-```
+```json
 {
     "hash": "289b76fbe40ca5e0d0df68016677a8c9be6389f3225cc9faf65cb92bbc98a3580b57cb7ba3d7f7ab36ce890d47a4be90254d407270ad4c2e69c99c998ef8547ca45f054b081959d4d59feb871360bce888f82b4cdc1476502bd1b8e95dffe811e55592d3d4768b56e0510e02b5e32171858de097cd811e7c8d09920c24960ae8"
 }
@@ -75,7 +75,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "hash": "69336bc69ac2b9d06d7b9f9ede253cbeadba227751125cbb220654499c59a7b5138ea06ff62670fae614e5fed26aec8d3a0f346e03f10ea6c83dcb20ba8d93d17d92fffd6604666034e7002f421e39e64cef43325dfdf2c0334e51e018a31710c8fac17214d96d309b8dddb8f9bf9b3a27d28c71016b93a0e89f588c3604420a",
     "proofhash": "0000000000036b5c62766b5781f78734cf336f6fc6bce0363b93092551390fa7bd4d942d20316758def777b770db0500c3910f43b147c006ad11246ae62ed28284a4af309aebdc31ed6df23ebc7218b5a638b4da42cb496661fb12cace6890b920233e7db70a3daa8b439e0973a0dd01be67db652eaf8e7281027228f47a89cf",
@@ -142,7 +142,7 @@ This method supports the Sorting / Filtering parameters.
 
 `time` : The unified time the block was created.
 
-`nonce` : The solution nonce
+`nonce` : The solution nonce.
 
 `bits` : The compact representation for the block difficulty.
 
@@ -184,9 +184,9 @@ This method supports the Sorting / Filtering parameters.
 {  
 `id` : The sequential ID of this contract within the transaction.
 
-`OP` : The contract operation. Can be APPEND, CLAIM, COINBASE, CREATE, CREDIT, DEBIT, FEE, GENESIS, LEGACY, TRANSFER, TRUST, STAKE, UNSTAKE, WRITE.
+`OP` : The contract operation. Can be APPEND, CLAIM, COINBASE, CREATE, CREDIT, DEBIT, FEE, GENESIS, LEGACY, TRANSFER, TRUST, STAKE, UNSTAKE, or WRITE.
 
-`for` : For CREDIT transactions, the contract that this credit was created for . Can be COINBASE, DEBIT, orLEGACY.
+`for` : For CREDIT transactions, the contract that this credit was created for. Can be COINBASE, DEBIT, or LEGACY.
 
 `txid` : The transaction that was credited / claimed.
 
@@ -204,7 +204,7 @@ This method supports the Sorting / Filtering parameters.
 
 `amount` : the token amount of the transaction.
 
-`token` : the register address of the token that the transaction relates to. Set to 0 for NXS transactions
+`token` : the register address of the token that the transaction relates to. Set to 0 for NXS transactions.
 
 `token_name` : The name of the token that the transaction relates to.
 
@@ -243,7 +243,7 @@ Retrieving block data by height is only allowed if the daemon has been configure
 
 #### Return value JSON object:
 
-```
+```json
 [
     {
         "hash": "5c985f5402f0bcb339ebef0e2edcad30427bf79803994772cd3a1458012748cd1d9d2ee8d6f1466f0c8ca867e1d8a2d9cfe6bc8cfdd885421fb56c55bfc11328f19c61bdc87193831851526a835e457fb46fcd0088879d564e88bb39524aa40489329ecc2cbc6a0453b8dd69a90b82232df6ee6d39ddec80e16149c99b1ddeab",
@@ -400,7 +400,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "txid": "017ff70158049886f8bad93cfe15285bae34d0e643991088e00769228161868a60230551724ac0ad5c7a98fabfdbebca88dffedf1a9e5ff095524b7565bccee1",
     "type": "tritium base",
@@ -431,7 +431,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return values:
 
-`data` : If format was specified as raw then the response will contain only the data field containing the raw, hex encoded, transaction data.
+`data` : If format was specified as raw then the response will contain only the data field containing the raw, hex-encoded, transaction data.
 
 `txid` : The transaction hash.
 
@@ -512,7 +512,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return value JSON object:
 
-```
+```json
 
 {
     "txid": "017ff70158049886f8bad93cfe15285bae34d0e643991088e00769228161868a60230551724ac0ad5c7a98fabfdbebca88dffedf1a9e5ff095524b7565bccee1",
@@ -619,9 +619,11 @@ ledger/submit/transaction
 
 #### Return value JSON object:
 
+```json
 {
     "hash": "47959e245f45aab773c0ce5320a5454f49ac15f63e15acb36855ac654d54d6314fe36b61dd64ec7a9a546bcc439a628e9badcdccb6e5f8072d04a0a3b67f8679"
 }
+```
 
 #### Return values:
 
@@ -645,7 +647,7 @@ ledger/get/info
 
 #### Return value JSON object:
 
-```
+```json
 {
     "stake": {
         "height": 1465766,
@@ -683,7 +685,7 @@ ledger/get/info
 
 #### Return values:
 
-`Stake` : This is the stake channel details.  
+`stake` : This is the stake channel details.  
 {  
 `height` : The current number of blocks for the stake channel.
 

--- a/docs/API/COMMANDS/PROFILES.MD
+++ b/docs/API/COMMANDS/PROFILES.MD
@@ -49,7 +49,7 @@ This command only supports the `master` and `auth` nouns.
 
 #### create/master ####
 
-This will create a new profile specified by given noun. The profile is secured by a combination of `username`, `password`, and `PIN`.
+This will create a new profile specified by given noun. The profile is secured by a combination of `username`, `password`, and `pin`.
 
 #### create/auth ####
 
@@ -67,7 +67,7 @@ This method will initialize a `auth` crypto object register for signature chains
 
 - `username` must be a minimum of 2 characters. 
 - `password` must be a minimum of 8 characters. 
-- `PIN` must be a minimum of 4 characters. 
+- `pin` must be a minimum of 4 characters. 
 -  username is case-sensitive and cannot be changed. Choose the username carefully and make it a point to back it up along with the password and pin.  
 - Don't use the colon ':' at the end of the username. 
  
@@ -76,7 +76,7 @@ This method will initialize a `auth` crypto object register for signature chains
 
 #### Return value JSON object:
 
-```
+```json
 {
     "success": true,
     "txid": "01d872456b966a14796d80f1687fe59a107fe6c3b6edd3558dce146d08f3093837136634022734d9d9b5e877311fd68f847f226ae276a12b8bc3f246513ccd08"
@@ -120,7 +120,7 @@ This method provides the user with the ability to set or change the restore seed
 
 #### update/credentials ####
 
-`new_password` : Required by noun **credentials**. The new password to set for for this signature chain. This is optional if new_pin is provided
+`new_password` : Required by noun **credentials**. The new password to set for for this signature chain. This is optional if new_pin is provided.
 
 `new_pin` : Required by noun **credentials**. The new pin to set for this signature chain. This is optional if `new_password` is provided.
 
@@ -131,16 +131,16 @@ This method provides the user with the ability to set or change the restore seed
 `new_recovery` : Required by noun **recovery**.The new recovery seed to set or change for this sig chain. The recovery seed must be a minimum of 40 characters.
 
 **NOTE:**
-The recovery phrase is case-sensitive.
-Make sure to type in the recovery phrase correctly and not copy paste which can add spaces if not done correctly.
-Make sure to backup and recheck the recovery seed and create multiple offline backups.  
+- The recovery phrase is case-sensitive.
+- Make sure to type in the recovery phrase correctly and not copy paste which can add spaces if not done correctly.
+- Make sure to backup and recheck the recovery seed and create multiple offline backups.  
 
 
 ## Results:
 
 #### Return value JSON object:
 
-```
+```json
 {
     "success": true,
     "txid": "01947f824e9b117d618ed49a7dd84f0e7c4bb0896e40d0a95e04e27917e6ecb6b9a5ccfba7d0d5c308b684b95e98ada4f39bbac84db75e7300a09befd1ac0999"
@@ -180,7 +180,7 @@ This command only supports the `master` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "success": true,
     "txid": "017fbb86583c0e15c0fb994a1f4c70d97f2c084533748ccfd25cd36e5aef9c2e7f89f15f2ec9f2d73769fef9d7a8a28cd018c9907ebf1bf74e4f89837c900091"
@@ -216,7 +216,7 @@ This command only supports the `master` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "genesis": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
     "confirmed": true,
@@ -263,7 +263,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return value JSON object:
 
-```
+```json
 [
     {
         "id": 0,
@@ -309,7 +309,7 @@ This method supports the Sorting / Filtering parameters.
 
 `proof` : The register address of the token account proving the the split dividend debit.
 
-`dividend_payment` : Flag indicating that this debit is a split dividend payment to a tokenized asset
+`dividend_payment` : Flag indicating that this debit is a split dividend payment to a tokenized asset.
 
 -----------------------------------
 
@@ -328,7 +328,7 @@ This command only supports the `master` noun.
 
 `session` : Required by **argument** `-multiuser=1` to be supplied to identify the user session that is creating the transaction.
 
-`verbose` : Optional, **determines** how much transaction data to include in the response. Supported values are :
+`verbose` : Optional, **determines** how much transaction data to include in the response. Supported values are:
 - `default` : hash
 - `summary` : type, version, sequence, timestamp, operation, and confirmations.
 - `detail` : genesis, nexthash, prevhash, pubkey and signature.
@@ -340,7 +340,7 @@ This method supports the Sorting / Filtering parameters.
 
 #### Return value JSON object:
 
-```
+```json
 [
     {
         "txid": "01eb59a0c4e6c47dd2a8d3a4aa7d83514aab6f5c976207889f786e5947c0eb971065fe6e0f8fc6b7d75157f9dac0cf0c178c15e441ff360c3046c84e1fe799ca",
@@ -406,7 +406,7 @@ This method supports the Sorting / Filtering parameters.
 
 `OP` : The contract operation. Can be APPEND, CLAIM, COINBASE, CREATE, CREDIT, DEBIT, FEE, GENESIS, LEGACY, TRANSFER, TRUST, STAKE, UNSTAKE, WRITE.
 
-`for` : For CREDIT transactions, the contract that this credit was created for . Can be COINBASE, DEBIT, orLEGACY.
+`for` : For CREDIT transactions, the contract that this credit was created for. Can be COINBASE, DEBIT, or LEGACY.
 
 `txid` : The transaction that was credited / claimed.
 
@@ -414,10 +414,9 @@ This method supports the Sorting / Filtering parameters.
 
 `proof` : The register address proving the credit.
 
-`from` : For DEBIT, CREDIT, FEE transactions, the register address of the account that the debit is being made from.
+`from` : For DEBIT, CREDIT, and FEE transactions, the register address of the account that the debit is being made from.
 
-`from_name` : For DEBIT, CREDIT, FEE transactions, the name of the account that the debit is being made from. Only included if the name can be 
-resolved.
+`from_name` : For DEBIT, CREDIT, and FEE transactions, the name of the account that the debit is being made from. Only included if the name can be resolved.
 
 `to` : For DEBIT and CREDIT transactions, the register address of the recipient account.
 

--- a/docs/API/COMMANDS/SESSIONS.MD
+++ b/docs/API/COMMANDS/SESSIONS.MD
@@ -104,7 +104,7 @@ These commands only supports the `local` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "unlocked": {
         "mining": false,
@@ -118,7 +118,7 @@ These commands only supports the `local` noun.
 
 #### Return values:
 
-`unlocked` : This will contain child elements describing which functions the session is currently unlocked for
+`unlocked` : This will contain child elements describing which functions the session is currently unlocked for.
 
 `mining` : Boolean flag indicating whether the users sig chain is unlocked for mining.
 
@@ -160,7 +160,7 @@ These commands only supports the `local` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "unlocked": {
         "mining": false,
@@ -174,7 +174,7 @@ These commands only supports the `local` noun.
 
 #### Return values:
 
-`unlocked` : This will contain child elements describing which functions the session is currently unlocked for
+`unlocked` : This will contain child elements describing which functions the session is currently unlocked for.
 
 `mining` : Boolean flag indicating whether the users sig chain is unlocked for mining.
 
@@ -214,7 +214,7 @@ NOTE:
 
 #### Return value JSON object:
 
-```
+```json
 {
     "genesis": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
     "success": true
@@ -261,7 +261,7 @@ NOTE:
 
 #### Return value JSON object:
 
-```
+```json
 {
     "genesis": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
     "session": "2ef9de11b19af82984ddf93275e7ba22c11fe9659d0667f79311c46732bbb7a4"
@@ -299,7 +299,7 @@ This command only supports the `local` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "success": true
 }
@@ -332,7 +332,7 @@ This command only supports the `local` noun.
 
 #### Return value JSON object:
 
-```
+```json
 {
     "genesis": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
     "accessed": 1653680627,

--- a/docs/API/COMMANDS/SYSTEM.MD
+++ b/docs/API/COMMANDS/SYSTEM.MD
@@ -31,7 +31,7 @@ system/stop
 
 password: Optional to **authenticate** before initiating core shutdown. This password is the one provided in the configuration file which will help prevent accidental remote shutdown.
 
-**Note:** The shutdown authentication password has to be provided in the configuration file with the flag `system/stop=<password>`
+**Note:** The shutdown authentication password has to be provided in the configuration file with the flag `system/stop=<password>`.
 
 ### Results:
 
@@ -60,7 +60,7 @@ system/get/metrics
 
 ##### Return value JSON object:
 
-```
+```json
 {
     "version": "5.1.0-rc2 Tritium++ CLI [LLD][x64]",
     "protocolversion": 3010000,
@@ -139,7 +139,7 @@ system/get/metrics
 
 #### Return value JSON object:
 
-```
+```json
 {
     "registers": {
         "total": 182682,
@@ -284,7 +284,7 @@ system/list/peers
 
 #### Return value JSON object:
 
-```
+```json
 [
     {
         "address": "45.180.14.231:9888",
@@ -366,7 +366,7 @@ system/list/lisp-eids
 
 #### Return value JSON object:
 
-```
+```json
 [
     {
         "instance-id": "200",
@@ -398,13 +398,13 @@ system/list/lisp-eids
 
 `instance-id` : The LISP instance group that this EID belongs to.
 
-`eid` : The endpoint identifier. This can be either IPv4 or IPv6 format
+`eid` : The endpoint identifier. This can be either IPv4 or IPv6 format.
 
-`rlocs` : The array of RLOC's (routing locators) associtated with the EID
+`rlocs` : The array of RLOC's (routing locators) associtated with the EID.
 
-`interface` : Name of the device for the RLOC
+`interface` : Name of the device for the RLOC.
 
-`rloc-name` : Hostname associated with the device
+`rloc-name` : Hostname associated with the device.
 
 `rloc` : The IP address associated with the device.
 
@@ -426,7 +426,7 @@ system/validate/address
 
 #### Return value JSON object:
 
-```
+```json
 {
     "address": "8BuhE1y5oard3cEWqCSYK35bC6LdPRvcPR8N7GXYNatTw6De8eK",
     "is_valid": true,

--- a/docs/API/FILTERING.MD
+++ b/docs/API/FILTERING.MD
@@ -19,7 +19,7 @@ commands/verb/noun/<filter>/operator
 
 In order to filter an object, one must know the JSON key they are filtering for.
 
-```
+```json
 {
     "id": 69,
     "OP": "CREDIT",
@@ -41,7 +41,7 @@ commands/verb/noun/OP,to,amount,ticker
 
 This would result in the following filtered object:
 
-```
+```json
 {
     "OP": "CREDIT",
     "to": "8BAv1H2YKfpaYC1RJMq9qjmMTiEV8DJiLpiKGqTY54wf2VPjznD",
@@ -56,7 +56,7 @@ One can include as many filters as desired, as long as keys exist in the returne
 
 JSON hierarchy can be maintained and traversed recursively to any depth of the data structure. Let us take the following JSON object, a verbose transaction:
 
-```
+```json
 {
     "txid": "019427d69187a02a23305a152c167c0c3fb547426afbdbee47ae674c7ea5a3d8f70e9a29c818f213edf1ce2721ae8bb81652e8cc77aac842df3c371027fa4e60",
     "type": "tritium user",
@@ -96,7 +96,7 @@ commands/verb/noun/type,confirmations,genesis,contracts.OP,contracts.to,contract
 
 When using recursive filtering, the nested hiearchy is retained.
 
-```
+```json
 {
     "type": "tritium user",
     "confirmations": 832340,

--- a/docs/API/OPERATORS.MD
+++ b/docs/API/OPERATORS.MD
@@ -15,7 +15,7 @@ In order to execute an operator, one must apply a basic filter to the data-set b
 
 Take the following contract list:
 
-```
+```json
 {
     "id": 33,
     "OP": "CREDIT",
@@ -54,7 +54,7 @@ commands/verb/noun/amount/sum
 
 This above command will return a JSON object with our filtered result:
 
-```
+```json
 {
     "amount": 414.53867,
 }
@@ -91,7 +91,7 @@ finance/list/accounts/balance/sum
 
 This command will return a sum of the balances for all accounts:
 
-```
+```json
 {
     "balance": 333.376
 }

--- a/docs/API/OVERVIEW.MD
+++ b/docs/API/OVERVIEW.MD
@@ -14,7 +14,7 @@ By default the API server runs on port 8080. This can be changed by setting `api
 
 ## `Security`
 The Nexus API uses the `HTTP Basic` authentication scheme.  This requires the caller to set an `Authorization` HTTP header with the value `Basic <credentials>` with the `<credendtials>` portion set to `apiuser:apipassword` and `base64` encoded. On the API server side the authentication is configured by adding `apiuser=<username>` and `apipassword=<password>` to the nexus.conf.   
-**NOTE**:  If you wish to disable authentication entirely, you can do so by setting `apiauth=0` in your nexus.conf
+**NOTE**:  If you wish to disable authentication entirely, you can do so by setting `apiauth=0` in your nexus.conf.
 
 
 The authentication mechanism is complemented by the implementation of `SSL` encryption (`HTTPS`).  By default the API server is started with SSL disabled.  To enable it, please add `apissl=1` to your nexus.conf   
@@ -44,7 +44,7 @@ http://127.0.0.1:8080/ledger/get/block
 # `Error Handling`
 
 In the event that an API call results in an error, a JSON object will be returned with the following format:
-```
+```json
 {
     "error" :
     {

--- a/docs/API/SORTING.MD
+++ b/docs/API/SORTING.MD
@@ -32,7 +32,7 @@ This above will map to the parameters of `limit=100` and `offset=10`.
 
 This parameter supports moving up levels of JSON keys by using `.`. This is a recursive function so therfore allows traversing any amount of levels in a JSON hierarchy. Let us take the following JSON object:
 
-```
+```json
 {
     "modified": 1621782289,
     "json": {
@@ -50,7 +50,7 @@ sort=json.date
 
 Using this parameter we would apply a sort to a nested JSON object that would sort it by the date field. The Nexus API supports any number of nested statements. Take the following object:
 
-```
+```json
 {
     "txid": "01c1e74718bbcbc83f46a0e03a86538350779f61df2e385a4456d3926808d3a29e3ac9d8d3ba2ea4b625b52b525d22fb675066184c4552c40824214b4f575e1c",
     "type": "tritium user",

--- a/docs/API/TEMPLATES.MD
+++ b/docs/API/TEMPLATES.MD
@@ -11,7 +11,7 @@ The following templates do not exceed a local scope, meaning they will return re
 The following list of verbs are templates throughout the Nexus APIs.  While the action is generic in nature (i.e. list, get, create), implementations of these actions will adhere to certain semantics or mandatory parameters regardless of the noun (resource).
 
 * `list`
-   - Retrieves a sorted list of objects or data
+   - Retrieves a sorted list of objects or data.
    - Sorting is based on transaction/object age, by default is always newest to oldest.  Some list methods support additional sort fields.
    - Common parameters:
      - `order` : The order of the results.  Values can be `desc` (default) or `asc`
@@ -21,7 +21,7 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
      - `verbose` : to indicate the verbosity of the data returned.  Values can be `default`, `summary`, or `detail`   
 
 * `get`
-   - Retrieves a single object or piece of data
+   - Retrieves a single object or piece of data.
    - Supported parameters:
      - `verbose` : to indicate the verbosity of the data returned.  Values can be `default`, `summary`, or `detail`   
 
@@ -40,7 +40,7 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
       Values can be `falcon` or `brainbpool`
 
 * `transfer`
-    - Transfers a single resource or object to another users's profile
+    - Transfers a single resource or object to another users's profile.
     - Common parameters:
       - `address`: the address of object to transfer
       - `recipient`: the profile-id of the sigchain receiving object.
@@ -48,7 +48,7 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
       Values can be `falcon` or `brainbpool`
 
 * `claim`
-    - Claims a single resource or object from a given transfer
+    - Claims a single resource or object from a given transfer.
     - Common parameters:
       - `address`: the address of object to claim
       - `txid`: the transaction-id of the transfer we are claiming.

--- a/docs/build-linux.md
+++ b/docs/build-linux.md
@@ -33,8 +33,8 @@ git checkout master
 # Compile the code. You can increase the number of jobs (-j X) to speed up compilation, if you have CPU and RAM available 
 make -j 4 -f makefile.cli
 
-# Optional step - copy the daemon to usr/bin so that it is available globally
-sudo cp nexus /usr/bin 
+# Optional step - link the daemon to usr/local/bin so that it is available globally
+sudo ln -s $(pwd)/nexus /usr/local/bin/nexus 
 
 ```
 <br />
@@ -81,7 +81,7 @@ processnotifications=1
 cd ~/.Nexus/
 
 # Download the bootstrap.  This will be 5GB or larger, so might take some time depending on your connection
-wget https://nexus.io/bootstrap/tritium/tritium.tar.gz
+wget http://bootstrap.nexus.io/tritium.tar.gz
 
 # Untar it
 tar -xvf tritium.tar.gz

--- a/docs/how-to-api.md
+++ b/docs/how-to-api.md
@@ -47,13 +47,13 @@ This will return all data in JSON format into your console.
 
 ### Results JSON
 The response JSON you will receive will contain one of two keys, results or error. When a command is successfully executed, you will receive a JSON string such as:
-```
+```json
 {"result":{"genesis":"69c2479c6780782448f419a0865542002ee85fec39228275b2db44bb6d3aa503","session":4940881975319897416}}
 ```
 
 You will need to parse out the values of the result object in your corresponding language of choice. If you happen to receive a failure, it will look like this:
 
-```
+```json
 {"error":{"code":-24,"message":"Missing Password"}}
 ```
 

--- a/docs/how-to-docker.md
+++ b/docs/how-to-docker.md
@@ -92,9 +92,9 @@ To get IPv6 to work in the container (which Nexus uses for crypto-EID support),
 you need to configure your docker daemon on your OS platform with the
 following:
 
-```
+```json
 {
-    "ipv6": true, "fixed-cidr-v6": '2001:db8:1::/64"
+    "ipv6": true, "fixed-cidr-v6": "2001:db8:1::/64"
 }
 ```
 


### PR DESCRIPTION
various typos, all under `docs`, as well as JSON formatting for the markdown. Only should have line substitutions/corrections.