### PR TITLE
Allowed for more items to be added on each item

### DIFF
--- a/src/TAO/API/commands/invoices/create.cpp
+++ b/src/TAO/API/commands/invoices/create.cpp
@@ -125,9 +125,26 @@ namespace TAO::API
                 { "units",       nUnits }
             };
 
-            /* Check for description key. */
-            if(CheckParameter(jItem, "description", "string"))
-                jNew["description"] = jItem["description"].get<std::string>();
+            /* Only search if there are more than the 2 required keys */
+            if (jItem.size() > 1) {
+
+                /* Add all other non-mandatory fields that the caller has provided for each item */
+                for(auto it = jItem.begin(); it != jItem.end(); ++it)
+                {
+                    /* Get our keyname. */
+                    const std::string strKey = ToLower(it.key());
+
+                    /* Skip any incoming parameters that are keywords used by this API method*/
+                    if(strKey == "amount"
+                    || strKey == "units")
+                    {
+                        continue;
+                    }
+
+                    /* add the field to the item */
+                    jNew[strKey] = it.value();
+                }
+            }
 
             /* Now add to our new items list. */
             jInvoice["items"].push_back(jNew);


### PR DESCRIPTION
Currently the documentation on creating a new invoice and the implementation do not align. In the docs, under `create` , an item could have more than `description` / `amount` / `units` but currently the code only accepted those 3. I have used the same routine that catches all the other fields in an invoice for each item as well. This will allow for each time to have unique fields separate from amount and units. These fields are read only and have no effect on the calculation of the invoice. It will also only run if there are more than 2 fields on an item, to avoid iterating over an item that has no extra fields. 
I currently push in the same json value that is given so there is a discussion to be had for casting into strings and or preventing complex types. 