### PR TITLE
List/blocks now handles chains smaller than the limit.

### DIFF
--- a/src/TAO/API/commands/ledger/list-blocks.cpp
+++ b/src/TAO/API/commands/ledger/list-blocks.cpp
@@ -107,8 +107,6 @@ namespace TAO::API
                 if(nHeight > bHeight)
                     throw Exception(-60, "[height] out of range [", bHeight, "]");
 
-                debug::log(0,"######### HIEHGt : ", nHeight , "  ,   " , bHeight);
-
                 /* Read the block state from the the ledger DB using the height index */
                 if(!LLD::Ledger->ReadBlock(nHeight, tLastBlock))
                     throw Exception(-83, "Block not found");


### PR DESCRIPTION
Previously if a user ran the list/blocks method while on a chain  with a height less than 10 (or the limit) the core would do one of 2 things:
* If indexheight was activated, the nHeight would become negative ( which you can not cast to a uint ) resulting in an overflow and would return an error. 
* if indexheight was NOT active, the core would get forced into an infinite loop and crash. 

This pull request fixes those two cases. I also made a few adjustments. One of which is moving the tLastBlock to reference the previous block. In my testing I found, in a chain of 6 , the first block was not returned. Although tested several times, this solution might not be adequate. 