### PR TITLE
Patch 1 - Docs update

### DIFF
--- a/docs/API/COMMANDS/REGISTER.MD
+++ b/docs/API/COMMANDS/REGISTER.MD
@@ -30,11 +30,12 @@ The following nouns are supported for this API command-set:
 [`finance:trust`] - An object register containing a token-id, balance, and trust.  
 [`finance:token`] - An object register containing a token-id, balance, supply, and decimals.  
 [`names:name`] - An object register containing names and global names.  
-[`names:namespace`] - An object register containing namespaces.  
+[`names:namespace`] - An object register containing namespaces.
+[`names:global`] - An object register containing global names.
 [`crypto`] - An object register which holds public key hashes.  
 [`object`] - An object register containing user-defined data structure.  
-[`raw`] -  An object register of type raw.  
-[`readonly`] - An object register of type readonly.  
+[`assets:raw`] -  An object register of type raw.  
+[`assets:readonly`] - An object register of type readonly.  
 [`append`] - An object register of type append.  
 [`any`] - An object selection noun allowing mixed accounts of different tokens.  
 
@@ -79,11 +80,11 @@ Retrieves information for a specified profile crypto object register.
 
 Retrieves information for a specified object register.
 
-#### get/readonly
+#### get/assets:readonly
 
 Retrieves information for a specified readonly register.
 
-#### get/raw
+#### get/assets:raw
 
 Retrieves information for a specified raw register.
 
@@ -134,6 +135,10 @@ Returns a list of all the names.
 
 Returns a list of all the namespaces.
 
+#### list/names:global
+
+Returns a list of all the global names.
+
 #### list/crypto
 
 Returns a list of all the crypto object registers.
@@ -176,23 +181,23 @@ register/history/noun
 
 This command supports all the nouns.
 
-#### history/account
+#### history/finance:account
 
 This will get the history and ownership of the specified NXS or token account.
 
-#### history/trust
+#### history/finance:trust
 
 This will get the history and ownership of the specified trust account. 
 
-#### history/token
+#### history/finance:token
 
 This will get the history and ownership of the specified token addresses.
 
-#### history/name
+#### history/names:name
 
 This will get the history and ownership of the specified name.
 
-#### history/namespace
+#### history/names:namespace
 
 This will get the history and ownership of the specified namespace.
 
@@ -204,11 +209,11 @@ This will get the history of the specified crypto object register.
 
 This will get the history and ownership of the specified object register.
 
-##### history/readonly
+##### history/assets:readonly
 
 This will get the history and ownership of the specified readonly register.
 
-#### history/raw
+#### history/assets:raw
 
 This will get the history and ownership of the specified raw register.
 

--- a/docs/API/COMMANDS/REGISTER.MD
+++ b/docs/API/COMMANDS/REGISTER.MD
@@ -26,11 +26,11 @@ The following verbs are currently supported by this API command-set:
 
 The following nouns are supported for this API command-set:
 
-[`account`] - An object register containing a token-id and balance.  
-[`trust`] - An object register containing a token-id, balance, and trust.  
-[`token`] - An object register containing a token-id, balance, supply, and decimals.  
-[`name`] - An object register containing names and global names.  
-[`namespace`] - An object register containing namespaces.  
+[`finance:account`] - An object register containing a token-id and balance.  
+[`finance:trust`] - An object register containing a token-id, balance, and trust.  
+[`finance:token`] - An object register containing a token-id, balance, supply, and decimals.  
+[`names:name`] - An object register containing names and global names.  
+[`names:namespace`] - An object register containing namespaces.  
 [`crypto`] - An object register which holds public key hashes.  
 [`object`] - An object register containing user-defined data structure.  
 [`raw`] -  An object register of type raw.  
@@ -51,23 +51,23 @@ register/get/noun
 
 This command supports all the nouns.
 
-#### get/account
+#### get/finance:account
 
 Retrieves information for a specified NXS or token account.
 
-#### get/trust
+#### get/finance:trust
 
 Retrieves information for a specified trust account.
 
-#### get/token
+#### get/finance:token
 
 Retrieves information for a specified token address.
 
-#### get/name
+#### get/names:name
 
 Retrieves information for a specified name.
 
-#### get/namespace
+#### get/names:namespace
 
 Retrieves information for a specified namespace.
 
@@ -114,23 +114,23 @@ register/list/noun
 
 This command supports all the nouns.
 
-#### list/account
+#### list/finance:account
 
 Returns a list of all NXS and token accounts.
 
-#### list/trust
+#### list/finance:trust
 
 Returns a list of all the trust accounts on the blockchain.
 
-#### list/token
+#### list/finance:token
 
 Returns a list of all the token address issued on the blockchain.
 
-#### list/name
+#### list/names:name
 
 Returns a list of all the names.
 
-#### list/namespace
+#### list/names:namespace
 
 Returns a list of all the namespaces.
 


### PR DESCRIPTION
Added a fix for REGISTER.md docs file, where the api call was not mentioned correctly.

Previously for token listing:

`register/list/token`

Fix includes placeholder for noun:

`register/list/finance:token`
