### PR TITLE
When throwing error, cast uint to int before printstr

### DIFF
--- a/src/Util/types/precision.h
+++ b/src/Util/types/precision.h
@@ -99,7 +99,7 @@ class precision_t
 
             /* Check that we are within correct digits. */
             if(fThrow && nDigitsCheck > nDigits)
-                throw debug::exception(FUNCTION, "Parameter can only have ", static_cast<int>(nDigits), " decimal places");
+                throw debug::exception(FUNCTION, "Parameter can only have ", uint32_t(nDigits), " decimal places");
         }
 
         /* Build a copy string to test. */
@@ -314,7 +314,7 @@ public:
 
                 /* Check if we have correct number of digits. */
                 if(nDigitsCheck > nDigits)
-                    throw debug::exception(FUNCTION, "Parameter can only have ", static_cast<int>(nDigits), " decimal places");
+                    throw debug::exception(FUNCTION, "Parameter can only have ", uint32_t(nDigits), " decimal places");
             }
         }
 

--- a/src/Util/types/precision.h
+++ b/src/Util/types/precision.h
@@ -99,7 +99,7 @@ class precision_t
 
             /* Check that we are within correct digits. */
             if(fThrow && nDigitsCheck > nDigits)
-                throw debug::exception(FUNCTION, "Parameter can only have ", nDigits, " decimal places");
+                throw debug::exception(FUNCTION, "Parameter can only have ", static_cast<int>(nDigits), " decimal places");
         }
 
         /* Build a copy string to test. */
@@ -314,7 +314,7 @@ public:
 
                 /* Check if we have correct number of digits. */
                 if(nDigitsCheck > nDigits)
-                    throw debug::exception(FUNCTION, "Parameter can only have ", nDigits, " decimal places");
+                    throw debug::exception(FUNCTION, "Parameter can only have ", static_cast<int>(nDigits), " decimal places");
             }
         }
 


### PR DESCRIPTION
When the incoming number's decimal was out of compliance with its base, the error message would return the uint8 value verbatim instead of a more readable base-10 value. 