### PR TITLE
Update for fully support ARM32(armv*l) with auto-detection.

### DIFF
--- a/docs/build-params-reference.md
+++ b/docs/build-params-reference.md
@@ -33,14 +33,14 @@ Example:
 32BIT=1
 ```
 
-#### `ARM64`
+#### `ARM`
 
-Set to build for ARM64 arch type.
+Set to build for ARM32(`armv*l`)/ARM64(`aarch64`) arch type.
 
 Example:
 
 ```
-ARM64=1
+ARM=1
 ```
 
 #### `OPENSSL LIBRARY PATH`

--- a/makefile.cli
+++ b/makefile.cli
@@ -33,27 +33,32 @@ ifeq (${STATIC}, 1)
 	endif
 endif
 
-#Configure for 32/64 Bit and ARM
+#Configure for 32BIT(x86)/64BIT(x64) and armvX(32BIT)/aarch64(64BIT)
 ifndef 32BIT
 	override 32BIT= 0
-
 endif
 ifeq (${32BIT}, 1)
 	BUILD_ARCH=x86
 	CXXFLAGS+= -m32
-
-else ifeq (${ARM64}, 1)
-        BUILD_ARCH=aarch64
-        CXXFLAGS+= -march=native -mtune=native
-
-else ifeq ($(shell uname -m),armv7l)
-        BUILD_ARCH=arm
+#Check 'ARM' flag is existed or not
+else ifeq (${ARM}, 1)
+	#Get architecture name from 'uname -m'
+	ARCH := $(shell uname -m)
+	ifeq ($(filter aarch64, $(ARCH)), $(ARCH)) #Check if the architecture is 'aarch64'(ARM64)
+        	BUILD_ARCH=aarch64
+        	CXXFLAGS+= -march=native -mtune=native
+	else ifeq ($(filter armv%, $(ARCH)), $(ARCH)) #Check if the architecture is 'armv*'(ARM32)
+        	BUILD_ARCH=arm
+		CXXFLAGS+= -march=native -mtune=native
+	else
+		#Display wrong flag error message with the name of current architecture.
+		$(error $'\n'Seems that you set the wrong 'ARM' flag, Your architecture is $(shell uname -m)).
+ 	endif
 
 else
 	BUILD_ARCH=x64
 	CXXFLAGS+= -m64
 endif
-
 
 #Define default LIB and INCLUDE path variables
 ifndef OPENSSL_LIB_PATH

--- a/src/Util/version.cpp
+++ b/src/Util/version.cpp
@@ -65,11 +65,13 @@ namespace version
     #endif
 
 
-    /* The Architecture (32-Bit, ARM 64, or 64-Bit) */
+    /* The Architecture (32-Bit, ARM 32/64, or 64-Bit) */
     #if defined x86
         const std::string BUILD_ARCH = "[x86]";
     #elif defined aarch64
         const std::string BUILD_ARCH = "[ARM aarch64]";
+    #elif defined arm
+	const std::string BUILD_ARCH = "[ARM arm32(armv*l)]";
     #else
         const std::string BUILD_ARCH = "[x64]";
     #endif


### PR DESCRIPTION
### `Description of Pull Request`
#### DISCLAIMER - PLEASE CHOOSE ONE OF THESE PULL REQUESTS BETWEEN AUTO DETECTION(THIS) AND [MANUAL DETECTION](https://github.com/Nexusoft/LLL-TAO/pull/212)
#### MERGE ONLY ONE, IF YOU MERGE ALL OF THESE AT THE SAME TIME, THE FIRST ONE THAT MERGED WILL BE OBSOLETED
-----------------------------------------------------------------------------
#### `Related issues that causing the problem`
- #208 

#### `Description of This Issue`
- Only <code>'armv7l'</code> recognized as <code>ARM32</code>, Other ARM 32-bit architectures(<code>armv*l</code>) cannot be recognized.
    - Because it prefixed as <code>'armv7l'</code> on the logic.
- Also it has different behavior for recognizing architecture between <code>ARM64(aarch64)</code> and this.
    - For recognizing <code>ARM64(aarch64)</code>, It needs <code>ARM64=1</code> flag.
    - But For <code>ARM32(armv7l)</code>, It uses <code>uname -m</code> for automatically recognizing.
- And the <code>'CXXFLAGS'</code> was missing, So could be the building processing not tweaked for the system.

#### `Related previous pull requests and issue`
- Issue : #50 
- PR : #52 

-----------------------------------------------------------------------------
#### ` The solution that be used in this fixment for fixing this issue`
1. **Add <code>'ARM=1'</code> flag for separating architecture recognition from <code>x86/64</code>.**
2. **Removal <code>'ARM64=1'</code> flag which not being used further.**
3. Add <code>'ARCH'</code> local variable for storing the value from <code>'uname -m'</code>, which contains the architecture information.
4. Add <code>$filter</code> for comparison the architecture types with string; if string value of <code>'ARCH'</code> contains <code>aarch</code>, <code>make</code> will choose the architecture as <code>'ARM64(aarch64)'</code>, else if it contains <code>armv</code>, <code>make</code> will choose the architecture as <code>'ARM32(aarch32)'</code>.
5. Add <code>'CXXFLAGS+= -mtune=native -march=native'</code> for tweaking the compiling process with local environment  on building.

You could review these changes with <code>git diff</code> or with the changelog below.

#### `Expected behavior after this merging`
No matter which ARM architecture that being used from user, It will be built handy with this instruction;
```
# 'N' is for counting of jobs for being used in building.
make -j N -f makefile.cli ARM=1 ... # The other building params continues.....
```

Also, The other `'ARM32'` architectures, such as `'armv6l'` and `'armv8l(aarch32)'` could be recognized.

----------------------------------------------------------------------------
#### `Targeted files for merging on this pull request and reasons`
- `'makefile.cli'` : Updated for recognizing the architecture properly, and automatically.
- `'build-params-reference.md'` : Removal the description of `'ARM64=1'` flag which not be used further, And add the description of `'ARM=1'` flag for used after this merging.
- `'version.cpp'` : Add `'[ARM arm32(armv*l)]'` for indicating the `'ARM32(armv*l)'` architecture on build version correctly.

----------------------------------------------------------------------------
#### `Tested environments and the results`
**`※ You can see the full log with click the model name below ※`**
- For `aarch64` / `armv8l(as aarch32 mode)` : [Raspberry Pi Model 4B(Cortex-A72, 8GB RAM)](https://github.com/user-attachments/files/20964561/rpi4-aarch64-auto-detection.log)
   - On Ubuntu Server 20.04 LTS 32-bit, the architecture shows as `'armv7l'`, So I tested with 64-bit version with 32-bit compatible mode(`'aarch32'`) for testing, Add pictures that built on 'Manual Detection' but seems that it won't be different on this 'Auto Detection'.(Because I couldn't make the environment of native `'armv8l'` now.)
   - The log of this section is for `'aarch64'`, Not being tested on other linux distributions, but it will be works. 
   
![ssh_screenshot](https://github.com/user-attachments/assets/a4140b39-8be1-4243-a34b-4f7f80f470aa)


- For `armv7l` : [Raspberry Pi Model 2B **Revision 1.1**(Cortex-A7, 1GB RAM)](https://github.com/user-attachments/files/20964560/rpi2-armv7l-auto-detection.log)
   - There's some warning notes that behavior of some methods had been changed on <code>GCC 7.1</code>, These can be ignored. The result is okay and working flawlessly. 

![wallet_screenshot](https://github.com/user-attachments/assets/4507a346-a8a5-416e-aaa2-c44b5f5b48b8)



