### PR TITLE
Update for fully support ARM32(armv*l) with manual-detection.

### DIFF
--- a/docs/build-params-reference.md
+++ b/docs/build-params-reference.md
@@ -33,9 +33,19 @@ Example:
 32BIT=1
 ```
 
+#### `ARM32`
+
+Set to build for ARM32(`armv*l`) arch type.
+
+Example:
+
+```
+ARM32=1
+```
+
 #### `ARM64`
 
-Set to build for ARM64 arch type.
+Set to build for ARM64(`aarch64`) arch type.
 
 Example:
 

--- a/makefile.cli
+++ b/makefile.cli
@@ -33,7 +33,7 @@ ifeq (${STATIC}, 1)
 	endif
 endif
 
-#Configure for 32/64 Bit and ARM
+#Configure for x86(32BIT)/x64(64BIT) and ARM32/64
 ifndef 32BIT
 	override 32BIT= 0
 
@@ -46,9 +46,9 @@ else ifeq (${ARM64}, 1)
         BUILD_ARCH=aarch64
         CXXFLAGS+= -march=native -mtune=native
 
-else ifeq ($(shell uname -m),armv7l)
+else ifeq (${ARM32}, 1)
         BUILD_ARCH=arm
-
+	CXXFLAGS+= -march=native -mtune=native
 else
 	BUILD_ARCH=x64
 	CXXFLAGS+= -m64

--- a/src/Util/version.cpp
+++ b/src/Util/version.cpp
@@ -65,11 +65,13 @@ namespace version
     #endif
 
 
-    /* The Architecture (32-Bit, ARM 64, or 64-Bit) */
+    /* The Architecture (32-Bit, ARM 32/64, or 64-Bit) */
     #if defined x86
         const std::string BUILD_ARCH = "[x86]";
     #elif defined aarch64
         const std::string BUILD_ARCH = "[ARM aarch64]";
+    #elif defined arm
+	const std::string BUILD_ARCH = "[ARM arm32(armv*l)]";
     #else
         const std::string BUILD_ARCH = "[x64]";
     #endif


### PR DESCRIPTION
### `Description of Pull Request`
#### DISCLAIMER - PLEASE CHOOSE ONE OF THESE PULL REQUESTS BETWEEN [AUTO DETECTION](https://github.com/Nexusoft/LLL-TAO/pull/211) AND MANUAL DETECTION(THIS)
#### MERGE ONLY ONE, IF YOU MERGE ALL OF THESE AT THE SAME TIME, THE FIRST ONE THAT MERGED WILL BE OBSOLETED
-----------------------------------------------------------------------------
#### `Related issues that causing the problem`
- #208 

#### `Description of This Issue`
- Only <code>'armv7l'</code> recognized as <code>ARM32</code>, Other ARM 32-bit architectures(<code>armv*l</code>) cannot be recognized.
    - Because it prefixed as <code>'armv7l'</code> on the logic.
- Also it has different behavior for recognizing architecture between <code>ARM64(aarch64)</code> and this.
    - For recognizing <code>ARM64(aarch64)</code>, It needs <code>ARM64=1</code> flag.
    - But For <code>ARM32(armv7l)</code>, It uses <code>uname -m</code> for automatically recognizing.
- And the <code>'CXXFLAGS'</code> was missing, So could be the building processing not tweaked for the system.

#### `Related previous pull requests and issue`
- Issue : #50 
- PR : #52 

-----------------------------------------------------------------------------
#### ` The solution that be used in this fixment for fixing this issue`
1. **Add <code>'ARM32=1'</code> flag for recognizing `'ARM32(armv*l)'`.**
2. **Removal <code>uname -m</code> recognition which only used for `'armv7l'` and not being used further.**
3. Add <code>'CXXFLAGS+= -mtune=native -march=native'</code> for tweaking the compiling process with local environment on building.

You could review these changes with <code>git diff</code> or with the changelog below.

#### `Expected behavior after this merging`
No matter which `ARM32(armv*l)` architecture that being used from user, It will be built handy with this instruction;
```
# 'N' is for counting of jobs for being used in building.
make -j N -f makefile.cli ARM32=1 ... # The other building params continues...
```

Also, The other `'ARM32'` architectures, such as `'armv6l'` and `'armv8l(aarch32)'` could be recognized.

On `'ARM64'` architectures, you can use the same method that used in before.
```
make -j N -f makefile.cli ARM64=1 ... # The other building params continues...
```

----------------------------------------------------------------------------
#### `Targeted files for merging on this pull request and reasons`
- `'makefile.cli'` : Updated for recognizing the architecture properly, and fully support for all type of ARM32 architecture.
- `'build-params-reference.md'` : Change the description of `'ARM64=1'` flag for indicating proper architecture, And add the description of `'ARM32=1'` flag for used after this merging.
- `'version.cpp'` : Add `'[ARM arm32(armv*l)]'` for indicating the `'ARM32(armv*l)'` architecture on build version correctly.

----------------------------------------------------------------------------
#### `Tested environments and the results`
**`※ You can see the full log with click the model name below ※`**
- For `aarch64` / `armv8l(as aarch32 mode)` : [Raspberry Pi Model 4B(Cortex-A72, 8GB RAM)](https://github.com/user-attachments/files/20964741/rpi4-aarch64-manual-detection.log)
   - On Ubuntu Server 20.04 LTS 32-bit, the architecture shows as `'armv7l'`, So I tested with 64-bit version with 32-bit compatible mode(`'aarch32'`) for testing, Add pictures that built on 'Manual Detection'
   - The log of this section is for `'aarch64'`, Not being tested on other linux distributions, but it will be works. 
   
![ssh_screenshot](https://github.com/user-attachments/assets/a4140b39-8be1-4243-a34b-4f7f80f470aa)


- For `armv7l` : [Raspberry Pi Model 2B **Revision 1.1**(Cortex-A7, 1GB RAM)](https://github.com/user-attachments/files/20964740/rpi2-armv7l-manual-detection.log)
   - There's some warning notes that behavior of some methods had been changed on <code>GCC 7.1</code>, These can be ignored. The result is okay and working flawlessly. 

![wallet_screenshot](https://github.com/user-attachments/assets/4507a346-a8a5-416e-aaa2-c44b5f5b48b8)

