### PR TITLE
Suggested fix to issue 192 (market - execution timestamp) + docs fixes

### DIFF
--- a/docs/API/COMMANDS/ASSETS.MD
+++ b/docs/API/COMMANDS/ASSETS.MD
@@ -33,14 +33,15 @@ The following verbs are currently supported by this command-set:
 | :-----:  | :-------- | :---- |
 |[`create`](#-create) | Generate a register of specified type | `asset`, `raw`, `readonly`, `schema` |
 |[`get`](#-get) | Get register of supported type | `any`, `asset`, `raw`, `readonly`, `schema`
-|[`list`](#-list) | List all registers owned by active session | `any`, `asset`, `raw`, `readonly`, `partial`, `schema` |
+|[`list`](#-list) | List all registers owned by active session | `any`, `asset`, `raw`, `readonly`, `schema` |
+|[`list/partial`](#listpartial) | List users partial ownership of tokenized assets | N/A (special command) |
 |[`transfer`](#-transfer) | Transfer a specified register | `any`, `asset`, `raw`, `readonly` |
 |[`claim`](#-claim) | Claim ownership of a register | `any`, `asset`, `raw`, `readonly` |
 |[`tokenize`](#-tokenize) | To represent ownership of an asset object with a token object | `asset` |
 |[`transactions`](#-transactions) | List all transactions that modified specified object | `any`, `asset`, `raw`, `readonly`, `schema` |
 |[`history`](#-history) | Generate the history of all last states | `any`, `asset`, `raw`, `readonly`, `schema` |
-|[`update`](#-update) | Update a specified object | `any`, `asset`, `raw`, `readonly`, `schema` |
-|[`verify`](#-verify) | Verify if a given register has been tokenized | `partial` |
+|[`update`](#-update) | Update a specified object | `asset`, `raw` |
+|[`verify/partial`](#verifypartial) | Verify if a given register has been tokenized | N/A (special command) |
 
 ### Example:
 
@@ -229,9 +230,9 @@ Retrieves a list of all the asset objects owned by the profile specified by the 
 assets/list/noun
 ```
 
-This command supports the `asset`, `readonly`, `raw`, and `any` nouns.
+This command supports the `asset`, `readonly`, `raw`, `any`, and `schema` nouns.
 
-#### list/assets
+#### list/asset
 
 Lists all the assets for object register type.
 
@@ -247,7 +248,7 @@ Lists all assets for raw register type.
 
 Lists all assets for all supported register types.
 
-[`list/partial`](#list/partial) - List users partial ownership details for tokenized assets.      
+See also: [`list/partial`](#listpartial) - List users partial ownership details for tokenized assets.      
 
 ### Parameters:
 
@@ -332,9 +333,9 @@ This updates the data values for the raw item register.
 
 `address` : Required to **identify** the register address of the asset. This is optional if the `name` is provided.
 
-`format` : Required to **specify** the format of the asset to update. Values can be `readonly`, `raw`, `basic` and `JSON`.
+`format` : Required to **specify** the format of the asset to update. Values can be `raw`, `basic` and `JSON`.
 
-`data` : Required if **format** is `readonly` or `raw`, allows caller to update the data object.  
+`data` : Required if **format** is `raw`, allows caller to update the data object.  
 
 `<fieldname>=<value>` : Optional for **format** `basic`, The caller can provide 'key=value' pairs to update each piece of data for the asset.
 
@@ -730,7 +731,7 @@ This command supports all nouns.
 
 -----------------------------------
 
-# <a name="list/partial"></a> `list/partial`
+# <a name="listpartial"></a> `list/partial`
 
 Retrieves a list of all the partial ownership details of tokenized assets for the user.
 
@@ -786,5 +787,44 @@ assets/list/partial
 `name` : The name identifying the asset.
 
 `ownership` : This is the percentage of the asset owned by the caller, based on the number of tokens owned.
+
+-----------------------------------
+
+# <a name="verifypartial"></a> `verify/partial`
+
+Verifies if a given token has been used to tokenize an asset. Returns the asset details if valid.
+
+```
+assets/verify/partial
+```
+
+### Parameters:
+
+`token` : Required to **identify** the token to verify. It can be the name (for global names), username:tokenname (for local names), or the register address of the token.
+
+
+### Results:
+
+#### Return value JSON object:
+
+```
+{
+    "asset": {
+        "address": "88NcYcKtMTRwtwDgfXFkZ4TbrHvkRGzsQkqVZco77Hqx1WRgCyi",
+        "owner": "d751c1ddbd2a50a0bee9883f4f8e029272551e8d09b336aeca876e1270e91422"
+    },
+    "valid": true
+}
+```
+
+#### Return Values:
+
+`asset` : Object containing the asset details if the token is valid.
+
+`asset.address` : The register address of the tokenized asset.
+
+`asset.owner` : The username hash of the profile that owns the asset.
+
+`valid` : Boolean flag indicating whether the token is a valid tokenized asset.
 
 -----------------------------------

--- a/docs/API/COMMANDS/FINANCE.MD
+++ b/docs/API/COMMANDS/FINANCE.MD
@@ -113,7 +113,7 @@ Deduct an amount of NXS or token specified by the noun and send it to another ac
 finance/debit/noun
 ```
 
-This command supports the any wildcard noun.
+This command supports the `account`, `token`, `trust` and `any` nouns.
 
 #### debit/account
 
@@ -161,13 +161,13 @@ This deducts an amount of tokens from a token address to send to a token account
 
 # <a name="credit"></a> `credit`
 
-Create a new object register specified by given noun.
+Claim funds issued to an account from a debit transaction.
 
 ```
 finance/credit/noun
 ```
 
-This command supports the any wildcard noun.
+This command supports the `account`, `token` and `any` nouns.
 
 #### credit/account
 
@@ -198,9 +198,9 @@ Increment an amount of tokens received from a token account.
 ```
 #### Return values:
 
-`txid` : The ID (hash) of the transaction that includes the account creation.
+`success` : Boolean flag indicating that the credit was successful.
 
-`address` : The register address for this  account. The address (or name that hashes to this address) is needed when creating crediting or debiting the account.
+`txid` : The ID (hash) of the transaction that includes the credit.
 
 -----------------------------------
 
@@ -259,7 +259,7 @@ Retrieves information for a single object for a type specified by the noun
 finance/get/noun
 ```
 
-This command supports the `account`, `trust` and `token` nouns.
+This command supports the `account`, `trust`, `token` and `any` nouns.
 
 #### get/account
 
@@ -352,7 +352,7 @@ This will list off all of the object register details specified by the noun.
 finance/list/noun
 ```
 
-This command supports the `account`, `trust` and `token` nouns.
+This command supports the `account`, `trust`, `token` and `any` nouns.
 
 #### list/account
 
@@ -447,7 +447,7 @@ This will get the history of the specified noun.
 finance/history/noun
 ```
 
-This command supports the `account`, `trust` and `token `nouns.
+This command supports the `account`, `trust`, `token` and `any` nouns.
 
 #### history/account
 
@@ -560,7 +560,7 @@ This will list off all of the transactions for the specified noun.
 finance/transactions/noun
 ```
 
-This command supports the account, trust and token nouns.
+This command supports the `account`, `trust`, `token` and `any` nouns.
 
 #### transactions/account
 

--- a/docs/API/COMMANDS/INVOICES.MD
+++ b/docs/API/COMMANDS/INVOICES.MD
@@ -20,7 +20,8 @@ The following verbs are currently supported by this API command-set:
 [`get`](#get) - Get object of supported type.  
 [`list`](#list) - List all objects owned by given user.  
 [`pay`](#pay) - Issue funds from supported type.  
-[`cancel`](#cancel) - To cancel the created invoice.   
+[`cancel`](#cancel) - To cancel the created invoice.  
+[`reject`](#reject) - To reject an invoice sent to you.  
 [`history`](#history) - Generate the history of all last states.  
 [`transactions`](#transactions) - List all transactions that modified specified object.  
 
@@ -29,10 +30,10 @@ The following verbs are currently supported by this API command-set:
 
 The following nouns are supported for this API command-set:
 
-[`invoice`] - An object register containing a token-id and balance.  
-[`outstanding`] - Generate the history of all last states.  
-[`paid`] - Claim a specified object register.  
-[`cancelled`] - Claim a specified object register.  
+[`invoice`] - An object register containing an invoice.  
+[`outstanding`] - Invoices that have been issued but not yet paid.  
+[`paid`] - Invoices that have been paid by the recipient.  
+[`cancelled`] - Invoices that were cancelled by the issuer.  
 
 
 
@@ -359,6 +360,44 @@ This command only supports the `invoice` and `outstanding` noun.
 
 -----------------------------------
 
+# <a name="reject"></a> `reject`
+
+Rejects an invoice that was sent to you, suppressing it from your notifications.
+
+```
+invoices/reject/noun
+```
+
+This command only supports the `invoice` and `outstanding` noun.
+
+**NOTE:** This does not cancel the invoice - the issuer can still cancel it. This simply removes the invoice from your pending notifications.
+
+### Parameters:
+
+`pin` : Required if **locked**. The PIN to authorize the transaction.
+
+`session` : Required by **argument** `-multiuser=1` to be supplied to identify the user session. For single-user API mode the session should not be supplied. 
+
+`name` : Required to **identify** the name of the invoice. The name should be in the format username:name (for local names). This is optional if the `address` is provided
+
+`address` : Required to **identify** the register address of the invoice. This is optional if the `name` is provided.
+
+### Results:
+
+#### Return value JSON object:
+
+```
+{
+    "success": true
+}
+```
+
+#### Return values:
+
+`success` : Boolean flag indicating that the invoice was rejected successfully.
+
+-----------------------------------
+
 # <a name="history"></a> `history`
 
 This will get the history of the transactions for an invoice showing when it was created & transferred (two contracts that happen at the same point in time when the invoice is created) and claimed (paid or cancelled).
@@ -475,7 +514,7 @@ This will list off all of the transactions for the specified noun.
 invoices/transactions/noun
 ```
 
-This command supports the account, trust and token nouns.
+This command supports all the nouns.
 
 ### Parameters:
 

--- a/docs/API/COMMANDS/LEDGER.MD
+++ b/docs/API/COMMANDS/LEDGER.MD
@@ -16,6 +16,8 @@ The following commands are direct endpoints and thus do not support the above ve
 [`submit/transaction`](#submit/transaction)  
 [`get/info`](#get/info)  
 [`get/metrics`](#get/metrics)  
+[`recent/blocks`](#recent/blocks)  
+[`sync/status`](#sync/status)  
 
 Direct endpoints support `filters` and `operators`.
 
@@ -356,7 +358,7 @@ ledger/list/blocks
 
 `contracts` : The array of contracts bound to this transaction and their details with opcodes.  
 {  
-`idcontractid` : The sequential ID of this contract within the transaction.
+`id` : The sequential ID of this contract within the transaction.
 
 `OP` : The contract operation. Can be APPEND, CLAIM, COINBASE, CREATE, CREDIT, DEBIT, FEE, GENESIS, LEGACY, TRANSFER, TRUST, STAKE, UNSTAKE, WRITE.
 
@@ -505,10 +507,10 @@ ledger/get/transaction
 
 # <a name="list/transactions"></a> `list/transactions`
 
-Retrieves transaction data for a given transaction hash.
+Retrieves a list of transactions from the mempool.
 
 ```
-ledger/get/transaction
+ledger/list/transactions
 ```
 
 ### Parameters:
@@ -946,5 +948,132 @@ ledger/get/metrics
 `monthly` : Total number of NXS locked or unlocked from stake in the last month.    
 }    
 }    
+
+-----------------------------------
+
+# <a name="recent/blocks"></a> `recent/blocks`
+
+Retrieves an array of recent block data, starting from the most recent block and working backwards.
+
+```
+ledger/recent/blocks
+```
+
+### Parameters:
+
+`limit` : Optional, the number of blocks to return. Default is 10, maximum is 1440. Only returns blocks from the last 28 days.
+
+`verbose` : Optional, determines how much **transaction data** to include in the response. Default is 1 (hash only). Supported values are:
+- `default` : hash.
+
+- `summary` : type, version, sequence, timestamp, and operation.
+
+- `detail` : genesis, nexthash, prevhash, pubkey and signature.
+
+[`Filtering`](/docs/API/FILTERING.MD). 
+
+### Returns:
+
+#### Return value JSON object:
+
+```
+[
+    {
+        "hash": "5c985f5402f0bcb339ebef0e2edcad30427bf79803994772cd3a1458012748cd1d9d2ee8d6f1466f0c8ca867e1d8a2d9cfe6bc8cfdd885421fb56c55bfc11328f19c61bdc87193831851526a835e457fb46fcd0088879d564e88bb39524aa40489329ecc2cbc6a0453b8dd69a90b82232df6ee6d39ddec80e16149c99b1ddeab",
+        "proofhash": "...",
+        "size": 807,
+        "height": 4555101,
+        "channel": 1,
+        "version": 8,
+        "merkleroot": "...",
+        "timestamp": 1658817563,
+        "date": "2022-07-26 06:39:23 UTC",
+        "nonce": 15731843013639865474,
+        "bits": "04c23531",
+        "difficulty": 7.9836465,
+        "mint": 1.92113,
+        "previousblockhash": "...",
+        "nextblockhash": "...",
+        "tx": [...]
+    }
+]
+```
+
+#### Return values:
+
+`hash` : The hash of the block.
+
+`proofhash` : The proof hash of the block.
+
+`size` : The block size in bytes.
+
+`height` : The block height.
+
+`channel` : The block channel (0=Stake, 1=Prime, 2=Hash).
+
+`version` : The serialization version of this block.
+
+`merkleroot` : The hash merkle root of the block transactions.
+
+`timestamp` : The Unix timestamp of when the block was created.
+
+`date` : The UTC date/time when the block was created.
+
+`nonce` : The solution nonce.
+
+`bits` : The compact representation for the block difficulty.
+
+`difficulty` : The channel specific difficulty.
+
+`mint` : The value minted in this block.
+
+`previousblockhash` : The hash of the previous block in the chain.
+
+`nextblockhash` : The hash of the next block in the chain, unless this is the last block in the chain.
+
+`tx` : An array of transactions included in this block (detail depends on verbose level).
+
+-----------------------------------
+
+# <a name="sync/status"></a> `sync/status`
+
+Returns the current synchronization status of the node.
+
+```
+ledger/sync/status
+```
+
+### Parameters:
+
+None.
+
+### Returns:
+
+#### Return value JSON object:
+
+```
+{
+    "networkBlock": 4595000,
+    "downloadRate": 125,
+    "completed": 99.85,
+    "progress": 95.5,
+    "secondsRemaining": 3600,
+    "timeRemaining": "01:00:00"
+}
+```
+
+#### Return values:
+
+`networkBlock` : The highest block height known from connected peers.
+
+`downloadRate` : The number of blocks downloaded per second.
+
+`completed` : The overall percentage of the blockchain synchronized (0-100).
+
+`progress` : The percentage progress of the current sync session (0-100).
+
+`secondsRemaining` : The estimated number of seconds remaining until sync is complete.
+
+`timeRemaining` : The estimated time remaining in HH:MM:SS format.
 
 -----------------------------------

--- a/docs/API/COMMANDS/MARKET.MD
+++ b/docs/API/COMMANDS/MARKET.MD
@@ -321,7 +321,7 @@ Retrieves a users market order information based on the noun.
 market/user/noun
 ```
 
-This command supports all the nouns.
+This command supports the `order` and `executed` nouns.
 
 
 ### Parameters:
@@ -330,7 +330,7 @@ This command supports all the nouns.
 
 `session` : Required by **argument** `-multiuser=1` to be supplied to identify the user session. For single-user API mode the session should not be supplied.
 
-`market` : Required to **identify** the market token pair.
+`token` : Required to **identify** the token to filter orders by. Can be a token name or register address.
 
 [`Sorting`](//docs/API/SORTING.MD).
 
@@ -345,7 +345,7 @@ This command supports all the nouns.
 
 ```
 {
-    "bids": [
+    "orders": [
         {
             "txid": "01722ce68a0fd5b22fdd5d1e90ec3ec4036f24592aafd9f414968a9c69355bb34012704bea1046557d81e297911c058b7623bd1f6c8a16974e5ed41528f1bb70",
             "timestamp": 1657201172,
@@ -369,14 +369,16 @@ This command supports all the nouns.
             }
         }
     ],
-    "asks": []
+    "executed": []
 }
 [Completed in 7.841892 ms]
 ```
 
 #### Return Values:
 
-`order` : The array for bid or ask orders.
+`orders` : The array of active orders for the user.
+
+`executed` : The array of executed orders for the user.
 
 `txid` : The hash of the transaction that was generated for this tx. If using -autotx this field will be ommitted.
 

--- a/docs/API/COMMANDS/NAMES.MD
+++ b/docs/API/COMMANDS/NAMES.MD
@@ -40,6 +40,8 @@ The following verbs are currently supported by this API command-set:
 [`claim`](#claim) - Claim ownership of an object register.  
 [`history`](#history) - Generate the history of all last states.  
 [`transactions`](#transactions) - List all transactions that modified specified object.  
+[`rename`](#rename) - Rename a local or namespaced name.  
+[`reverse`](#reverse) - Reverse lookup a name from an address.  
  
 
 ## `Supported Nouns`
@@ -50,6 +52,7 @@ The following nouns are supported for this API command-set:
 [`namespace`] - An object register containing a namespace object.  
 [`global`] - An object register which is recognised globally on the network.  
 [`local`] - An object register which is recognised only within the context of a user profile.  
+[`inactive`] - A name object that has been disabled (address set to 0).  
 [`any`] - An object selection noun allowing mixed names nouns.  
 
 -----------------------------------
@@ -324,7 +327,7 @@ This method allows the register address within a name object to be changed.
 names/update/noun
 ```
 
-This command does not support the `name` `namespace`or `any` nouns.
+This command supports all the nouns.
 
 ### Parameters:
 
@@ -493,7 +496,7 @@ This command supports all the nouns.
 
 `address` : Required to **identify** the name using the register address. This is optional if the `name` is provided.
 
-#### history/namesapce
+#### history/namespace
 
 `namespace` : Required to **identify** the Name of the namespace object. This is optional if the namespace `address` is provided.
 
@@ -578,7 +581,7 @@ This command supports all the nouns.
 
 `address` : Required to **identify** the name using the register address. This is optional if the `name` is provided.
 
-#### transactions/namesapce
+#### transactions/namespace
 
 `namespace` : Required to **identify** the Name of the namespace object. This is optional if the namespace `address` is provided.
 
@@ -682,5 +685,103 @@ This method supports the Sorting / Filtering parameters.
 
 `object` : Returns a list of all the object details (register, name or namespace).
 )
+
+-----------------------------------
+# <a name="rename"></a> `rename`
+
+This will rename a local or namespaced name to a new name within the same namespace.
+
+```
+names/rename/noun
+```
+
+This command supports the `name` and `local` nouns.
+
+**NOTE:** Global names cannot be renamed.
+
+### Parameters:
+
+`pin` : Required if **locked**. The PIN to authorize the transaction.
+
+`session` : Required by **argument** `-multiuser=1` to be supplied to identify the user session. For single-user API mode the session should not be supplied.
+
+`name` : Required to **identify** the current name to be renamed. The name should be in the format name (for local names) or namespace::name (for names in a namespace).
+
+`new` : Required the **new name** that the name should be renamed to.
+
+### Results:
+
+#### Return value JSON object:
+
+```
+{
+    "success": true,
+    "txid": "01947f824e9b117d618ed49a7dd84f0e7c4bb0896e40d0a95e04e27917e6ecb6b9a5ccfba7d0d5c308b684b95e98ada4f39bbac84db75e7300a09befd1ac0999"
+}
+[Completed in 4981.591417 ms]
+```
+
+#### Return values:
+
+`success` : Boolean flag indicating that the name was renamed successfully.
+
+`txid` : The ID (hash) of the transaction for the rename operation.
+
+-----------------------------------
+
+# <a name="reverse"></a> `reverse`
+
+This will perform a reverse lookup of a name from a register address.
+
+```
+names/reverse/lookup
+```
+
+This command uses the `lookup` noun.
+
+### Parameters:
+
+`session` : Required by **argument** `-multiuser=1` to be supplied to identify the user session. For single-user API mode the session should not be supplied.
+
+`address` : Required the **register address** to lookup the name for.
+
+### Results:
+
+#### Return value JSON object:
+
+```
+{
+    "owner": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
+    "version": 1,
+    "created": 1656571493,
+    "modified": 1656571493,
+    "type": "OBJECT",
+    "register": "8BJ747ASK45oU7UC5e2dePXeMviskmU1t5Kd4iyKLdSiCgKtLcJ",
+    "name": "Block_Token",
+    "namespace": "",
+    "address": "8HeR7kxrk9zsAcEAqaQaD2juMnZ73m4WDb4sW16pW93qd7i2Q3G"
+}
+[Completed in 0.418167 ms]
+```
+
+#### Return values:
+
+`owner` : The username hash of the owners profile.
+
+`version` : The serialization version of the Name.
+
+`created` : The UNIX timestamp when the Name was created.
+
+`modified` : The UNIX timestamp when the Name was last modified.
+
+`type` : Asset register type. Can be OBJECT, RAW or READONLY.
+
+`register` : The register address of the object that this Name points to.
+
+`name` : The name identifying the object register.
+
+`namespace` : The namespace that the name was created in. Empty for local names, ~GLOBAL~ for global names.
+
+`address` : The register address of the Name.
 
 -----------------------------------

--- a/docs/API/COMMANDS/PROFILES.MD
+++ b/docs/API/COMMANDS/PROFILES.MD
@@ -22,6 +22,7 @@ The following verbs are currently supported by this API command-set:
 [`status`](#status) - Retreives status information for a profile.  
 [`notifications`](#notifications) - List all notifications that modified specified object.  
 [`transactions`](#transactions) - List all transactions that modified specified object.  
+[`list`](#list) - List all object registers owned by the profile.  
 
 -----------------------------------
 
@@ -33,6 +34,7 @@ The following nouns are supported for this API command-set:
 [`auth`] - Crypto object register for login auth.  
 [`credentials`] - Credentials used to secure profiles.  
 [`recovery`] - An object which represents the recovery seed for the profile.  
+[`register`] - An object register owned by the profile (used by list).  
 
 -----------------------------------
 
@@ -294,8 +296,6 @@ This command only supports the `master` noun.
 
 `txid` : The transaction that was credited / claimed.
 
-`suppressed`: If the caller included the optional suppressed flag, then the response will include this field to indicate whether this notification is currently being suppressed or not.
-
 `from` : For DEBIT transactions, the register address of the account that the debit is being made from.
 
 `from_name` : For DEBIT transactions, the name of the account that the debit is being made from. Only included if the name can be resolved.
@@ -444,5 +444,69 @@ resolved.
 
 `object` : Returns a list of all hashed public keys in the crypto object register for the specified profile. The object result will contain the nine default keys(app1, app2, app3, auth, cert lisp, network, sign  and verify).  
 }  
+
+-----------------------------------
+
+# <a name="list"></a> `list`
+
+This will list all object registers owned by the profile.
+
+```
+profiles/list/noun
+```
+
+This command only supports the `register` noun.
+
+
+### Parameters:
+
+`session` : Required by **argument** `-multiuser=1` to be supplied to identify the user profile.
+
+`where` : An array of clauses to **filter** the JSON results. More information on filtering the results from /list/xxx API methods can be found at [`Queries`](/docs/API/QUERIES.md).
+
+[`Sorting`](//docs/API/SORTING.MD).
+
+[`Filtering`](/docs/API/FILTERING.MD).
+
+[`Operators`](//docs/API/OPERATORS.MD). 
+
+
+### Results:
+
+#### Return value JSON object:
+
+```
+[
+    {
+        "owner": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
+        "version": 1,
+        "created": 1654620591,
+        "modified": 1654620591,
+        "type": "OBJECT",
+        "address": "89AVoe5S8gjZpVngYoYtqJbSr9fGsdsoXShxnyNaEGPvMMeDnT6",
+        "name": "default",
+        "standard": "ACCOUNT"
+    }
+]
+[Completed in 0.256792 ms]
+```
+
+#### Return values:
+
+`owner` : The profile genesis hash that owns the register.
+
+`version` : The serialization version of the register.
+
+`created` : The UNIX timestamp when the register was created.
+
+`modified` : The UNIX timestamp when the register was last modified.
+
+`type` : The type of register (OBJECT, RAW, READONLY, APPEND).
+
+`address` : The register address of the object.
+
+`name` : The name of the register if one was provided.
+
+`standard` : The standard type of the object (ACCOUNT, TOKEN, CRYPTO, NAME, NAMESPACE, etc.).
 
 -----------------------------------

--- a/docs/API/COMMANDS/REGISTER.MD
+++ b/docs/API/COMMANDS/REGISTER.MD
@@ -30,14 +30,21 @@ The following nouns are supported for this API command-set:
 [`finance:trust`] - An object register containing a token-id, balance, and trust.  
 [`finance:token`] - An object register containing a token-id, balance, supply, and decimals.  
 [`names:name`] - An object register containing names and global names.  
-[`names:namespace`] - An object register containing namespaces.
-[`names:global`] - An object register containing global names.
+[`names:namespace`] - An object register containing namespaces.  
+[`names:global`] - An object register containing global names.  
+[`names:local`] - An object register containing local names.  
+[`assets:asset`] - An object register containing asset data.  
+[`assets:raw`] - An object register of type raw for assets.  
+[`assets:readonly`] - An object register of type readonly for assets.  
+[`supply:item`] - An object register containing supply item data.  
+[`supply:raw`] - An object register of type raw for supply.  
+[`supply:readonly`] - An object register of type readonly for supply.  
+[`invoices:invoice`] - An object register containing invoice data.  
 [`crypto`] - An object register which holds public key hashes.  
 [`object`] - An object register containing user-defined data structure.  
-[`assets:raw`] -  An object register of type raw.  
-[`assets:readonly`] - An object register of type readonly.  
-[`append`] - An object register of type append.  
-[`any`] - An object selection noun allowing mixed accounts of different tokens.  
+[`raw`] - An object register of type raw.  
+[`readonly`] - An object register of type readonly.  
+[`any`] - An object selection noun allowing mixed registers of different types.  
 
 -----------------------------------
 
@@ -87,10 +94,6 @@ Retrieves information for a specified readonly register.
 #### get/assets:raw
 
 Retrieves information for a specified raw register.
-
-#### get/append
-
-Retrieves information for a specified append register.
 
 ### Parameters:
 
@@ -147,17 +150,13 @@ Returns a list of all the crypto object registers.
 
 Returns a list of all the object registers.
 
-#### list/readonly
-
-Returns a list of all the readonly registers.
-
 #### list/raw
 
 Returns a list of all the raw registers.
 
-#### list/append
+#### list/readonly
 
-Returns a list of all the append registers.
+Returns a list of all the readonly registers.
 
 ### Parameters:
 
@@ -209,17 +208,13 @@ This will get the history of the specified crypto object register.
 
 This will get the history and ownership of the specified object register.
 
-##### history/assets:readonly
+#### history/assets:readonly
 
 This will get the history and ownership of the specified readonly register.
 
 #### history/assets:raw
 
 This will get the history and ownership of the specified raw register.
-
-#### history/append
-
-This will get the history and ownership of the specified append register.
 
 ### Parameters:
 
@@ -245,23 +240,23 @@ register/transactions/noun
 
 This command supports all the nouns.
 
-#### transactions/account
+#### transactions/finance:account
 
 List out all the transactions for the specified NXS account or token account.
 
-#### transactions/trust
+#### transactions/finance:trust
 
-List out all the transactions for the specified trust account
+List out all the transactions for the specified trust account.
 
-#### transactions/token
+#### transactions/finance:token
 
 List out all the transactions for the specified token address.
 
-#### transactions/name
+#### transactions/names:name
 
 List out all the transactions for the specified name.
 
-#### transactions/namespace
+#### transactions/names:namespace
 
 List out all the transactions for the specified namespace.
 
@@ -280,10 +275,6 @@ List out all the transactions for the specified readonly register.
 #### transactions/raw
 
 List out all the transactions for the specified raw register.
-
-#### transactions/append
-
-List out all the transactions for the specified append register.
 
 ### Parameters:
 
@@ -310,25 +301,25 @@ All these calls will require the latest build of the core and will not work with
 To calculate the sum of all NXS on the tritium chain:
 
 ```
-register/list/accounts,trust/total/sum sort=total order=desc limit=none where='object.token=0'
+register/list/finance:account,finance:trust/total/sum sort=total order=desc limit=none where='results.token=0'
 ```
 
 List all the namespaces created in ascending order:
 
 ```
-register/list/namespaces sort=created order=asc
+register/list/names:namespace sort=created order=asc
 ```
 
 List all the global names on the network:
 
 ```
-register/list/names where=object.namespace=~GLOBAL~
+register/list/names:global
 ```
 
 Create a rich list:
 
 ```
-register/list/accounts,trust sort=total order=desc page=0 where=(object.token=0)
+register/list/finance:account,finance:trust sort=total order=desc page=0 where=(results.token=0)
 ```
 
 -----------------------------------

--- a/docs/API/COMMANDS/SESSIONS.MD
+++ b/docs/API/COMMANDS/SESSIONS.MD
@@ -22,9 +22,11 @@ The following verbs are currently supported by this API command-set:
 [`unlock`](#unlock)       - Unlock the session to carry out specified operations.     
 [`lock`](#lock)           - Lock the session to stop a specified operations.  
 [`save`](#save)           - Save a specified session to the local database.     
-[`load`](#load)           - Load a specified session from the local database.     
+[`load`](#load)           - Load a specified session from the local database.  
+[`list`](#list)           - List all active sessions (requires -multiusername).  
 [`terminate`](#terminate) - Terminates a session specified by the noun.          
 [`status`](#status)       - Returns status information for the session specified by the noun.  
+[`validate`](#validate)   - Validates a pin against the current session.  
 
 
 
@@ -33,13 +35,7 @@ The following verbs are currently supported by this API command-set:
 The following nouns are supported for this API command-set:
 
 [`local`] - The location of the session.
-
------------------------------------
-## `Direct Endpoints`
-
-The following commands are direct endpoints and thus do not support the above verb and noun structure available above.
-
-[`validate/pin`](#validate/pin)
+[`pin`] - Used for pin validation operations.
 
 -----------------------------------
 
@@ -160,7 +156,7 @@ These commands only supports the `local` noun.
 
 `staking` : Required for **locking** staking transactions. This boolean value locks the session for staking.
 
-`transactions : Required for **locking** transactions. This boolean value locks the session for creating or claiming transactions.
+`transactions` : Required for **locking** transactions. This boolean value locks the session for creating or claiming transactions.
 
 
 ### Returns:
@@ -281,6 +277,54 @@ These commands only supports the `local` noun.
 
 -----------------------------------
 
+# <a name="list"></a> `list`
+
+This will list all currently active sessions. This command is only available when the `-multiusername` flag is enabled.
+
+```
+sessions/list/noun
+```
+
+This command only supports the `local` noun.
+
+**NOTE:** This command requires the `-multiusername` startup flag to be enabled.
+
+### Parameters:
+
+None.
+
+
+### Results:
+
+#### Return value JSON object:
+
+```
+[
+    {
+        "username": "user1",
+        "genesis": "b7fa11647c02a3a65a72970d8e703d8804eb127c7e7c41d565c3514a4d3fdf13",
+        "session": "2ef9de11b19af82984ddf93275e7ba22c11fe9659d0667f79311c46732bbb7a4",
+        "accessed": 1653680627,
+        "duration": 3600
+    }
+]
+[Completed in 0.072625 ms]
+```
+
+#### Return values:
+
+`username` : The username of the profile for this session.
+
+`genesis` : The profile genesis hash. This is a hash of the profile username.
+
+`session` : The session ID for this active session.
+
+`accessed` : The UNIX timestamp at which the session was last accessed.
+
+`duration` : The number of seconds since the session was last accessed.
+
+-----------------------------------
+
 # <a name="terminate"></a> `terminate`
 
 This will terminate an active session specified by given noun.
@@ -371,13 +415,15 @@ This command only supports the `local` noun.
 
 -----------------------------------
 
-# <a name="validate/pin"></a> `validate/pin`
+# <a name="validate"></a> `validate`
 
 Validates a pin/string against the current logged in session. Uses the internal authentication logic to attempt to authenticate with the supplied string. This allows for UI layers to gatekeep information without executing a command.  
 
 ```
 sessions/validate/pin
 ```
+
+This command only supports the `pin` noun.
 
 ### Parameters:
 

--- a/docs/API/COMMANDS/SUPPLY.MD
+++ b/docs/API/COMMANDS/SUPPLY.MD
@@ -56,7 +56,7 @@ Create a new object register specified by given noun.
 supply/create/noun
 ```
 
-This command only supports the `item`, `raw` `readonly` and `any` nouns.
+This command supports the `item`, `raw`, `readonly` and `any` nouns.
 
 #### create/item
 
@@ -202,7 +202,7 @@ supply/list/noun
 
 This command supports the `item`, `raw`, `readonly` and `any` nouns.
 
-#### list/items
+#### list/item
 
 Lists all the items for object register type.
 
@@ -294,7 +294,7 @@ This method provides the user with the ability to update the object data specifi
 supply/update/noun
 ```
 
-This command only supports the `item` and `raw` nouns.
+This command supports the `item`, `raw` and `any` nouns.
 
 #### update/item
 
@@ -314,7 +314,7 @@ This updates the data value for the raw item register.
 
 `address` : Required to **identify** the item to update by register address. This is optional if the `name` is provided.
 
-`format` : Required to **specify** the format of the asset to update. Values can be `readonly`, `raw`, `basic` and `JSON`. 
+`format` : Required to **specify** the format of the asset to update. Values can be `raw`, `basic` and `JSON`. 
 
 `data` : Required if **format** is `raw`, allows caller to update the data object. 
 
@@ -348,7 +348,7 @@ This will initiate ownership transfer of the specified noun.
 supply/transfer/noun
 ```
 
-This command supports the `item`,  `raw` and `readonly` nouns.
+This command supports the `item`, `raw`, `readonly` and `any` nouns.
 
 #### transfer/item
 
@@ -403,7 +403,7 @@ This method will claim ownership of the item to complete the corresponding trans
 supply/claim/noun
 ```
 
-This command supports the `item`,  `raw` and `readonly` nouns.
+This command supports the `item`, `raw`, `readonly` and `any` nouns.
 
 #### claim/item
 

--- a/docs/API/COMMANDS/SYSTEM.MD
+++ b/docs/API/COMMANDS/SYSTEM.MD
@@ -74,10 +74,11 @@ system/get/info
     "multiuser": false,
     "litemode": false,
     "blocks": 4553990,
-    "synchronizing": false,
-    "synccomplete": 100,
-    "syncprogress": 100,
+    "status": "Synchronized",
+    "synchronized": true,
+    "syncing": false,
     "txtotal": 0,
+    "conflicts": 0,
     "connections": 41
 }
 [Completed in 0.070190 ms]
@@ -95,29 +96,35 @@ system/get/info
 
 `hostname` : The local machine host name.
 
-`ipaddress` : The public IP address of the local machine, as seen by peers that you are connected to. This will be blank until you have at least one peer connection.
+`directory` : The current data directory.
+
+`address` : The public IP address of the local machine, as seen by peers that you are connected to. This will be blank until you have at least one peer connection.
 
 `testnet` : If this node is running on the testnet then this shows the testnet number.
 
 `private` : Whether this node is running in private mode.
 
+`hybrid` : Whether this node is running in hybrid mode.
+
+`latency` : Only returned in hybrid or private mode. The latency parameter value in milliseconds.
+
 `multiuser` : Whether this node is running in multiuser mode.
 
-`sessions` : Only returned in multiuser mode. This shows the number of user sessions currently logged in to the node.
-
-`clientmode` : Flag indicating whether this node is running in client mode.
+`litemode` : Flag indicating whether this node is running in lite (client) mode.
 
 `nolegacy` : Flag indicating whether this node has been compiled with support for the legacy UTxO wallet. If it has not then all of the legacy wallet functions (available via the legacy RPC) are not available. This flag is currently omitted from the response if it has been compiled with legacy support, hence it will only be included if it is true.
 
 `blocks` : The current block height of this node.
 
-`synchronizing` : Flag indicating whether this node is currently syncrhonizing. Not included if private=true.
+`status` : The current status message for this node (e.g., "Synchronized", "Synchronizing", etc.).
 
-`synccomplete` : The percentage of the total blocks downloaded.
+`synchronized` : Flag indicating whether this node is currently synchronized with the network.
 
-`syncprogress` : The percentage of the current sync completed relative to when the node was started.
+`syncing` : Contains sync status information when the node is synchronizing. Returns `false` when not syncing, or an object with sync details when syncing.
 
 `txtotal` : Number of transactions in the node's mempool.
+
+`conflicts` : Number of conflicting transactions in the node's mempool.
 
 `connections` : Number of peer connections.
 
@@ -311,6 +318,8 @@ system/list/peers
 `height` : The current height of the peer.
 
 `best` : Block hash of the peer's best chain
+
+`genesis` : The genesis hash of the peer's logged in profile (if available).
 
 `latency` : The calculated network latency between this node and the peer.
 

--- a/docs/API/ERRORS.MD
+++ b/docs/API/ERRORS.MD
@@ -33,7 +33,7 @@ The API supports many different error responses to help you as the developer und
 | -8 | Unable to Extract Input Address |
 | -9 | Session (session) doesn't exist |
 | -10 | Invalid session ID |
-| -11 | User not logged in |
+| -11 | Session not found |
 | -12 | Malformed or missing object encoding for [type] |
 | -13 | Object not found |
 | -14 | Malformed request URL |
@@ -45,7 +45,7 @@ The API supports many different error responses to help you as the developer und
 | -20 | Field [name] is read-only and can't be updated |
 | -21 | Field [name] size exceeds maximum length [size] |
 | -22 | Field [name] is a reserved field name |
-| -23 | Object standard [name] not available for command |
+| -23 | Object standard [name] not available for command (also: Command disabled until sigchain finishes synchronizing) |
 | -24 | No orders found for market |
 | -25 | Market order invalid contract: message |
 | -26 | Invalid parameter [from], [type] requires correct token |
@@ -264,7 +264,6 @@ The API supports many different error responses to help you as the developer und
 | -239 | Invalid item number of units |
 | -240 | Item units must be greater than 0 |
 | -241 | Invoice not found |
-| -242 | Data at this address is not an invoice |
 | -242 | Data exceeds max register size |
 | -243 | Data at this address is not a supply item |
 | -244 | Cannot send invoice to self |
@@ -330,4 +329,5 @@ The API supports many different error responses to help you as the developer und
 | -307 | Failed to download signature chain |
 | -308 | API method only available in client mode |
 | -309 | Error loading session |
-| -310 | Cannot sent to ALL accounts
+| -310 | (reserved) |
+| -333 | Account failed to authenticate |

--- a/docs/API/FILTERING.MD
+++ b/docs/API/FILTERING.MD
@@ -94,7 +94,7 @@ These nested JSON objects and arrays can be filtered recursively using the `.` o
 commands/verb/noun/type,confirmations,genesis,contracts.OP,contracts.to,contracts.amount,contracts.ticker
 ```
 
-When using recursive filtering, the nested hiearchy is retained.
+When using recursive filtering, the nested hierarchy is retained.
 
 ```
 {

--- a/docs/API/FORMATS.MD
+++ b/docs/API/FORMATS.MD
@@ -1,6 +1,6 @@
 # `Formats`
 
-When creating or modifying a register for any command-set, a format is required to encode the operations to the given register. The following sections outline the formats and their corresponding syntax. This syntax is accessed when one supplies `format=basic` as a paramter to a command that creates a new register, or updates its current state.
+When creating or modifying a register for any command-set, a format is required to encode the operations to the given register. The following sections outline the formats and their corresponding syntax. This syntax is accessed when one supplies `format=basic` as a parameter to a command that creates a new register, or updates its current state.
 
 ## `readonly` or `raw`
 
@@ -45,7 +45,7 @@ Would result in an object with the following structure:
     "type": "OBJECT",
     "field1" : "value1",
     "field2" : "value2",
-    "field3" : "321"
+    "field3" : "321",
     "address": "87Wai2JoS4hNAEVXZVmejLS6pK21XQWKoLAkaep5aXFdrYnJJyk",
     "name": "test"
 }
@@ -68,13 +68,15 @@ Would result in an object with the following structure:
     "type": "OBJECT",
     "field1" : "100",
     "field2" : "value2",
-    "field3" : "321"
+    "field3" : "321",
     "address": "87Wai2JoS4hNAEVXZVmejLS6pK21XQWKoLAkaep5aXFdrYnJJyk",
     "name": "test"
 }
 ```
 
 **NOTE:** The basic format only works for an object register of supported type `asset` or `schema`.
+
+**TIP:** To create a read-only (immutable) field using the basic format, prefix the value with `const:`. For example: `field1=const:myvalue` will create a field that cannot be updated after creation.
 
 ## `JSON`
 

--- a/docs/API/OPERATORS.MD
+++ b/docs/API/OPERATORS.MD
@@ -70,6 +70,8 @@ The following operators are supported for this API command-set:
 
 [`floor`](#floor) - Convert all values in a result to integers by stripping off decimals.
 
+[`lookup`](#lookup) - Resolve a list of register addresses to their full register objects.
+
 [`max`](#max)     - Find the maximum value in the given set, and return this as result.
 
 [`mean`](#mean)   - Calculate the mean or average value across a set of filtered results.  

--- a/docs/API/PROTOCOL.MD
+++ b/docs/API/PROTOCOL.MD
@@ -47,7 +47,7 @@ If accessing through php or other means, refer to their relevant documentation t
 
 ## `Authentication`
 
-The API supports the `HTTP Basic` authentication scheme.  This requires the caller to set an `Authorization` HTTP header with the value `Basic <credentials>` with the `<credendtials>` portion set to `apiuser:apipassword` in `base64` encoding. On the API server side the authentication is configured by adding `apiuser=<username>` and `apipassword=<password>` to the nexus.conf.  If you wish to disable authentication entirely, you can do so by setting `apiauth=0` in your nexus.conf, the daemon will not start the API server if you do not configure credentials or set `-apiauth=0` in your configuration.
+The API supports the `HTTP Basic` authentication scheme.  This requires the caller to set an `Authorization` HTTP header with the value `Basic <credentials>` with the `<credentials>` portion set to `apiuser:apipassword` in `base64` encoding. On the API server side the authentication is configured by adding `apiuser=<username>` and `apipassword=<password>` to the nexus.conf.  If you wish to disable authentication entirely, you can do so by setting `apiauth=0` in your nexus.conf, the daemon will not start the API server if you do not configure credentials or set `-apiauth=0` in your configuration.
 
 
 ## `Sessions`

--- a/docs/API/QUERIES.md
+++ b/docs/API/QUERIES.md
@@ -6,11 +6,11 @@ The Query DSL allows you to sort and filter recursively to any logical depth. Th
 
 ## Using wildcards
 
-If you are searching by a string parameter, you can includeM' as an any character wildcard match, so that you can search values
+If you are searching by a string parameter, you can include '*' as an any character wildcard match, so that you can search values
 based on a partial match.
 
 ```
-register/list/accounts WHERE 'results.name=d*'
+register/list/finance:accounts WHERE 'results.name=d*'
 ```
 
 The above will return all accounts that start with a letter 'd'.
@@ -20,7 +20,7 @@ The above will return all accounts that start with a letter 'd'.
 The following demonstrates how to check with wildcards.
 
 ```
-register/list/accounts WHERE 'results.name=*d'
+register/list/finance:accounts WHERE 'results.name=*d'
 ```
 
 This above will return all accounts that have a name ending with letter 'd'.
@@ -30,9 +30,9 @@ This above will return all accounts that have a name ending with letter 'd'.
 
 To filter, you can use where='statements' or follow the command with WHERE string:
 
-### Filtering resultss with WHERE clause
+### Filtering results with WHERE clause
 
-The below clause will filter all name results registers, that are Global names that start with letter 'P', or any resultss that start
+The below clause will filter all name results registers, that are Global names that start with letter 'P', or any results that start
 with letter 'S'.
 
 ```
@@ -41,13 +41,13 @@ register/list/names WHERE '(results.namespace=*GLOBAL* AND results.name=P*) OR r
 
 Using the results class i.e. 'results.namespace' will invoke the filter on the binary results.
 
-### Filtering resultss with where=
+### Filtering results with where=
 
-The below clause will filter all name results registers, that are Global names that start with letter 'P', or any resultss that start
+The below clause will filter all name results registers, that are Global names that start with letter 'P', or any results that start
 with letter 'S'.
 
 ```
-register/list/names where='(results.namespace=*GLOBAL* AND results.name=P*) OR results.name=S*'
+register/list/names where='(results.global=true AND results.name=P*) OR results.name=S*'
 ```
 
 ### Filtering with multiple operators
@@ -55,7 +55,7 @@ register/list/names where='(results.namespace=*GLOBAL* AND results.name=P*) OR r
 The below will return all NXS accounts that have a balance greater than 10 NXS.
 
 ```
-register/list/accounts WHERE 'results.token=0 AND results.balance>10'
+register/list/finance:accounts WHERE 'results.token=0 AND results.balance>10'
 ```
 
 ### Creating logical grouping
@@ -63,7 +63,7 @@ register/list/accounts WHERE 'results.token=0 AND results.balance>10'
 The following demonstrates how to query using multiple recursive levels.
 
 ```
-register/list/accounts WHERE '(results.token=0 AND results.balance>10) OR (results.token=8Ed7Gzybwy3Zf6X7hzD4imJwmA2v1EYjH2MNGoVRdEVCMTCdhdK AND results.balance>1)'
+register/list/finance:accounts WHERE '(results.token=0 AND results.balance>10) OR (results.token=8Ed7Gzybwy3Zf6X7hzD4imJwmA2v1EYjH2MNGoVRdEVCMTCdhdK AND results.balance>1)'
 ```
 
 This will give all NXS accounts with balance greater than 10, or all accounts for token '8Ed7Gzybwy3Zf6X7hzD4imJwmA2v1EYjH2MNGoVRdEVCMTCdhdK' with balance greater than 1.
@@ -74,8 +74,8 @@ This will give all NXS accounts with balance greater than 10, or all accounts fo
 There is no current limit to the number of levels of recursion, such as:
 
 ```
-register/list/names WHERE '((results.name=d* AND results.namespace=~GLOBAL~) OR (results.name=e* AND results.namespace=send.to)) OR results.namespace=*s'
+register/list/names:name WHERE '((results.name=d* AND results.global=true) OR (results.name=e* AND results.namespace=send.to)) OR results.namespace=*s'
 ```
 
-The above command will return all resultss starting with letter 'd' that are global names, or all resultss starting with letter 'e' in
-the 'send.to' namespace, or finally all resultss that are in a namespace that ends with the letter 's'.
+The above command will return all results starting with letter 'd' that are global names, or all results starting with letter 'e' in
+the 'send.to' namespace, or finally all results that are in a namespace that ends with the letter 's'.

--- a/docs/API/SORTING.MD
+++ b/docs/API/SORTING.MD
@@ -22,7 +22,7 @@ The following parameters can be used to apply **sorting** to the returned data-s
 The `limit` and `offset` parameters can be given with the following format:
 
 ```
-limit=100.10
+limit=100,10
 ```
 
 This above will map to the parameters of `limit=100` and `offset=10`.
@@ -30,7 +30,7 @@ This above will map to the parameters of `limit=100` and `offset=10`.
 
 ## `Recursive Sorting`
 
-This parameter supports moving up levels of JSON keys by using `.`. This is a recursive function so therfore allows traversing any amount of levels in a JSON hierarchy. Let us take the following JSON object:
+This parameter supports moving up levels of JSON keys by using `.`. This is a recursive function so therefore allows traversing any amount of levels in a JSON hierarchy. Let us take the following JSON object:
 
 ```
 {

--- a/docs/API/TEMPLATES.MD
+++ b/docs/API/TEMPLATES.MD
@@ -30,14 +30,14 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
    - Common parameters:
      - `format` : indicates the format of the data being provided to create the item / object (where applicable). Values can be `basic`, `raw`, and `JSON`
      - `scheme` : sets the key type to be used for the given transaction.
-     Values can be `falcon` or `brainbpool`
+     Values can be `falcon` or `brainpool`
 
  * `update`
     - Updates a single resource or object.
     - Common parameters:
       - `format` : indicates the format of the data being provided to create the item / object (where applicable). Values can be `basic`, `raw`, `standard`, and `JSON`
       - `scheme` : sets the key type to be used for the given transaction.
-      Values can be `falcon` or `brainbpool`
+      Values can be `falcon` or `brainpool`
 
 * `transfer`
     - Transfers a single resource or object to another users's profile
@@ -45,7 +45,7 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
       - `address`: the address of object to transfer
       - `recipient`: the profile-id of the sigchain receiving object.
       - `scheme` : sets the key type to be used for the given transaction.
-      Values can be `falcon` or `brainbpool`
+      Values can be `falcon` or `brainpool`
 
 * `claim`
     - Claims a single resource or object from a given transfer
@@ -53,7 +53,7 @@ The following list of verbs are templates throughout the Nexus APIs.  While the 
       - `address`: the address of object to claim
       - `txid`: the transaction-id of the transfer we are claiming.
       - `scheme` : sets the key type to be used for the given transaction.
-      Values can be `falcon` or `brainbpool`
+      Values can be `falcon` or `brainpool`
 * `history`
     - List the history of state changes for a given object.
     - Common parameters:

--- a/src/LLD/contract.cpp
+++ b/src/LLD/contract.cpp
@@ -60,8 +60,14 @@ namespace LLD
 
     /* Writes a caller that fulfilled a conditional agreement.*/
     bool ContractDB::WriteContract(const std::pair<uint512_t, uint32_t>& pair,
-                                   const uint256_t& hashCaller, const uint8_t nFlags)
+                                   const uint256_t& hashCaller, const uint512_t& hashExecution,
+                                   const uint8_t nFlags)
     {
+        /* Build our contract data struct. */
+        ContractData tData;
+        tData.hashCaller    = hashCaller;
+        tData.hashExecution = hashExecution;
+
         /* Memory mode for pre-database commits. */
         if(nFlags == TAO::Ledger::FLAGS::MEMPOOL)
         {
@@ -72,13 +78,13 @@ namespace LLD
             {
                 /* Write proof to memory. */
                 pMemory->setErase.erase(pair);
-                pMemory->mapContracts[pair] = hashCaller;
+                pMemory->mapContracts[pair] = tData;
 
                 return true;
             }
 
             /* Write proof to commited memory. */
-            pCommit->mapContracts[pair] = hashCaller;
+            pCommit->mapContracts[pair] = tData;
 
             return true;
         }
@@ -88,7 +94,7 @@ namespace LLD
 
             /* Check for pending transactions. */
             if(pMiner)
-                pMiner->mapContracts[pair] = hashCaller;
+                pMiner->mapContracts[pair] = tData;
 
             return true;
         }
@@ -98,7 +104,7 @@ namespace LLD
 
             /* Check for pending transactions. */
             if(pSanitize)
-                pSanitize->mapContracts[pair] = hashCaller;
+                pSanitize->mapContracts[pair] = tData;
 
             return true;
         }
@@ -120,7 +126,7 @@ namespace LLD
                 return true;
         }
 
-        return Write(pair, hashCaller);
+        return Write(pair, tData);
     }
 
 
@@ -174,7 +180,8 @@ namespace LLD
 
 
     /* Reads a caller that fulfilled a conditional agreement.*/
-    bool ContractDB::ReadContract(const std::pair<uint512_t, uint32_t>& pairContract, uint256_t& hashCaller, const uint8_t nFlags)
+    bool ContractDB::ReadContract(const std::pair<uint512_t, uint32_t>& pairContract, uint256_t& hashCaller,
+                                  uint512_t& hashExecution, const uint8_t nFlags)
     {
         /* Memory mode for pre-database commits. */
         if(nFlags == TAO::Ledger::FLAGS::MEMPOOL)
@@ -185,7 +192,9 @@ namespace LLD
             if(pMemory && pMemory->mapContracts.count(pairContract))
             {
                 /* Get the state from temporary transaction. */
-                hashCaller = pMemory->mapContracts[pairContract];
+                const ContractData& tData = pMemory->mapContracts[pairContract];
+                hashCaller    = tData.hashCaller;
+                hashExecution = tData.hashExecution;
 
                 return true;
             }
@@ -194,7 +203,9 @@ namespace LLD
             if(pCommit->mapContracts.count(pairContract))
             {
                 /* Get the state from commited memory. */
-                hashCaller = pCommit->mapContracts[pairContract];
+                const ContractData& tData = pCommit->mapContracts[pairContract];
+                hashCaller    = tData.hashCaller;
+                hashExecution = tData.hashExecution;
 
                 return true;
             }
@@ -207,7 +218,9 @@ namespace LLD
             if(pMiner && pMiner->mapContracts.count(pairContract))
             {
                 /* Get the state from temporary transaction. */
-                hashCaller = pMiner->mapContracts[pairContract];
+                const ContractData& tData = pMiner->mapContracts[pairContract];
+                hashCaller    = tData.hashCaller;
+                hashExecution = tData.hashExecution;
 
                 return true;
             }
@@ -220,14 +233,24 @@ namespace LLD
             if(pSanitize && pSanitize->mapContracts.count(pairContract))
             {
                 /* Get the state from temporary transaction. */
-                hashCaller = pSanitize->mapContracts[pairContract];
+                const ContractData& tData = pSanitize->mapContracts[pairContract];
+                hashCaller    = tData.hashCaller;
+                hashExecution = tData.hashExecution;
 
                 return true;
             }
         }
 
         /* Check our disk state first. */
-        return Read(pairContract, hashCaller);
+        ContractData tData;
+        if(!Read(pairContract, tData))
+            return false;
+
+        /* Extract values from struct. */
+        hashCaller    = tData.hashCaller;
+        hashExecution = tData.hashExecution;
+
+        return true;
     }
 
 

--- a/src/LLD/types/contract.h
+++ b/src/LLD/types/contract.h
@@ -23,9 +23,33 @@ ________________________________________________________________________________
 
 #include <TAO/Ledger/include/enum.h>
 
+#include <Util/templates/serialize.h>
+
 
 namespace LLD
 {
+
+    /** ContractData
+     *
+     *  Helper struct for storing contract execution data.
+     *
+     **/
+    struct ContractData
+    {
+        /** The genesis hash of the caller that fulfilled the contract. **/
+        uint256_t hashCaller;
+
+        /** The transaction hash of the execution transaction. **/
+        uint512_t hashExecution;
+
+        /** Serialization **/
+        IMPLEMENT_SERIALIZE
+        (
+            READWRITE(hashCaller);
+            READWRITE(hashExecution);
+        )
+    };
+
 
     /** RegisterTransaction
      *
@@ -37,7 +61,7 @@ namespace LLD
     public:
 
         /** Map of states that are stored in memory mode until commited. **/
-        std::map<std::pair<uint512_t, uint32_t>, uint256_t> mapContracts;
+        std::map<std::pair<uint512_t, uint32_t>, ContractData> mapContracts;
 
 
         /** Set of indexes to remove during commit. **/
@@ -89,13 +113,14 @@ namespace LLD
          *
          *  @param[in] pairContract The origin contract
          *  @param[in] hashCaller The caller that fulfilled agreement.
+         *  @param[in] hashExecution The transaction hash of the execution.
          *  @param[in] nFlags The flags for memory or not.
          *
          *  @return True if written, false otherwise.
          *
          **/
         bool WriteContract(const std::pair<uint512_t, uint32_t>& pair, const uint256_t& hashCaller,
-                           const uint8_t nFlags = TAO::Ledger::FLAGS::BLOCK);
+                           const uint512_t& hashExecution, const uint8_t nFlags = TAO::Ledger::FLAGS::BLOCK);
 
 
         /** EraseContract
@@ -117,13 +142,14 @@ namespace LLD
          *
          *  @param[in] pairContract The origin contract.
          *  @param[out] hashCaller The caller that fulfilled agreement.
+         *  @param[out] hashExecution The transaction hash of the execution.
          *  @param[in] nFlags The flags for memory or not.
          *
          *  @return True if the caller was read, false otherwise.
          *
          **/
         bool ReadContract(const std::pair<uint512_t, uint32_t>& pair, uint256_t& hashCaller,
-                          const uint8_t nFlags = TAO::Ledger::FLAGS::BLOCK);
+                          uint512_t& hashExecution, const uint8_t nFlags = TAO::Ledger::FLAGS::BLOCK);
 
 
         /** HasCaontract

--- a/src/LLP/lookup.cpp
+++ b/src/LLP/lookup.cpp
@@ -299,7 +299,7 @@ namespace LLP
 
                                                 /* Check that we have the contract validated. */
                                                 if(!LLD::Contract->HasContract(std::make_pair(hashTx, nContract)))
-                                                    LLD::Contract->WriteContract(std::make_pair(hashTx, nContract), tx.hashGenesis);
+                                                    LLD::Contract->WriteContract(std::make_pair(hashTx, nContract), tx.hashGenesis, hash);
                                             }
                                             else
                                             {

--- a/src/TAO/API/commands/market/json.cpp
+++ b/src/TAO/API/commands/market/json.cpp
@@ -27,7 +27,8 @@ ________________________________________________________________________________
 namespace TAO::API
 {
     /* Converts an order for marketplace into formatted JSON. */
-    encoding::json Market::OrderToJSON(const TAO::Operation::Contract& rContract, const std::pair<uint256_t, uint256_t>& pairMarket)
+    encoding::json Market::OrderToJSON(const TAO::Operation::Contract& rContract, const std::pair<uint256_t, uint256_t>& pairMarket,
+                                       const uint64_t nExecutionTimestamp)
     {
         /* Start our stream at 0. */
         rContract.Reset();
@@ -63,11 +64,14 @@ namespace TAO::API
                     else
                         strMarket += strName;
 
+                    /* Use execution timestamp if provided, otherwise use order creation time. */
+                    const uint64_t nTimestamp = (nExecutionTimestamp > 0) ? nExecutionTimestamp : rContract.Timestamp();
+
                     /* Build our JSON object. */
                     encoding::json jRet =
                     {
                         { "txid",      rContract.Hash().ToString()   },
-                        { "timestamp", rContract.Timestamp()         },
+                        { "timestamp", nTimestamp                    },
                         { "owner",     rContract.Caller().ToString() },
                         { "market",    strMarket                     }
                     };
@@ -224,7 +228,8 @@ namespace TAO::API
 
 
     /* Converts an order for marketplace into formatted JSON. */
-    encoding::json Market::OrderToJSON(const TAO::Operation::Contract& rContract, const uint256_t& hashBase)
+    encoding::json Market::OrderToJSON(const TAO::Operation::Contract& rContract, const uint256_t& hashBase,
+                                       const uint64_t nExecutionTimestamp)
     {
         /* Start our stream at 0. */
         rContract.Reset();
@@ -299,12 +304,12 @@ namespace TAO::API
                     {
                         /* This is an ask if for native token. */
                         pairMarket.first = hashBuying;
-                        return OrderToJSON(rContract, pairMarket);
+                        return OrderToJSON(rContract, pairMarket, nExecutionTimestamp);
                     }
 
                     /* Otherwise this is a bid. */
                     pairMarket.first = hashSelling;
-                    return OrderToJSON(rContract, pairMarket);
+                    return OrderToJSON(rContract, pairMarket, nExecutionTimestamp);
                 }
                 catch(const std::exception& e)
                 {

--- a/src/TAO/API/commands/market/list.cpp
+++ b/src/TAO/API/commands/market/list.cpp
@@ -99,9 +99,25 @@ namespace TAO::API
                         if(LLD::Ledger->HasProof(hashRegister, pairOrder.first, pairOrder.second) && !fExecuted)
                             continue;
 
+                        /* Get execution timestamp if this is an executed order. */
+                        uint64_t nExecutionTimestamp = 0;
+                        if(fExecuted)
+                        {
+                            /* Read the execution transaction hash. */
+                            uint256_t hashCaller;
+                            uint512_t hashExecution;
+                            if(LLD::Contract->ReadContract(pairOrder, hashCaller, hashExecution, TAO::Ledger::FLAGS::MEMPOOL))
+                            {
+                                /* Get the execution transaction to retrieve its timestamp. */
+                                TAO::Ledger::Transaction txExecution;
+                                if(LLD::Ledger->ReadTx(hashExecution, txExecution))
+                                    nExecutionTimestamp = txExecution.nTimestamp;
+                            }
+                        }
+
                         /* Get our order's json. */
                         encoding::json jOrder =
-                            OrderToJSON(tContract, pairMarket);
+                            OrderToJSON(tContract, pairMarket, nExecutionTimestamp);
 
                         /* Check for null value. */
                         if(jOrder.is_null())
@@ -186,9 +202,25 @@ namespace TAO::API
                         if(LLD::Ledger->HasProof(hashRegister, pairOrder.first, pairOrder.second) && !fExecuted)
                             continue;
 
+                        /* Get execution timestamp if this is an executed order. */
+                        uint64_t nExecutionTimestamp = 0;
+                        if(fExecuted)
+                        {
+                            /* Read the execution transaction hash. */
+                            uint256_t hashCaller;
+                            uint512_t hashExecution;
+                            if(LLD::Contract->ReadContract(pairOrder, hashCaller, hashExecution, TAO::Ledger::FLAGS::MEMPOOL))
+                            {
+                                /* Get the execution transaction to retrieve its timestamp. */
+                                TAO::Ledger::Transaction txExecution;
+                                if(LLD::Ledger->ReadTx(hashExecution, txExecution))
+                                    nExecutionTimestamp = txExecution.nTimestamp;
+                            }
+                        }
+
                         /* Get our order's json. */
                         encoding::json jOrder =
-                            OrderToJSON(tContract, pairMarket);
+                            OrderToJSON(tContract, pairMarket, nExecutionTimestamp);
 
                         /* Check for null value. */
                         if(jOrder.is_null())

--- a/src/TAO/API/commands/market/user.cpp
+++ b/src/TAO/API/commands/market/user.cpp
@@ -167,9 +167,24 @@ namespace TAO::API
                         if(!TAO::Register::Unpack(tContract, hashRegister))
                             continue;
 
+                        /* Get execution timestamp for this executed order. */
+                        uint64_t nExecutionTimestamp = 0;
+                        {
+                            /* Read the execution transaction hash. */
+                            uint256_t hashCaller;
+                            uint512_t hashExecution;
+                            if(LLD::Contract->ReadContract(pairOrder, hashCaller, hashExecution, TAO::Ledger::FLAGS::MEMPOOL))
+                            {
+                                /* Get the execution transaction to retrieve its timestamp. */
+                                TAO::Ledger::Transaction txExecution;
+                                if(LLD::Ledger->ReadTx(hashExecution, txExecution))
+                                    nExecutionTimestamp = txExecution.nTimestamp;
+                            }
+                        }
+
                         /* Get our order's json. */
                         encoding::json jOrder =
-                            OrderToJSON(tContract, hashBase);
+                            OrderToJSON(tContract, hashBase, nExecutionTimestamp);
 
                         /* Check for valid base token. */
                         const std::pair<uint256_t, uint256_t> pairMarket = std::make_pair

--- a/src/TAO/API/types/commands/market.h
+++ b/src/TAO/API/types/commands/market.h
@@ -137,12 +137,14 @@ namespace TAO::API
          *
          *  @param[in] rContract The contract to de-serialize
          *  @param[in] pairMarket The market pair ordering.
+         *  @param[in] nExecutionTimestamp Optional execution timestamp for executed orders (0 = use order creation time).
          *
          *  @return the formatted JSON object
          *
          **/
         __attribute__((pure)) encoding::json OrderToJSON(const TAO::Operation::Contract& rContract,
-                                                         const std::pair<uint256_t, uint256_t>& pairMarket);
+                                                         const std::pair<uint256_t, uint256_t>& pairMarket,
+                                                         const uint64_t nExecutionTimestamp = 0);
 
 
         /** OrderToJSON
@@ -151,11 +153,13 @@ namespace TAO::API
          *
          *  @param[in] rContract The contract to de-serialize
          *  @param[in] hashBase The market base pair for ordering.
+         *  @param[in] nExecutionTimestamp Optional execution timestamp for executed orders (0 = use order creation time).
          *
          *  @return the formatted JSON object
          *
          **/
-        __attribute__((pure)) encoding::json OrderToJSON(const TAO::Operation::Contract& rContract, const uint256_t& hashBase);
+        __attribute__((pure)) encoding::json OrderToJSON(const TAO::Operation::Contract& rContract, const uint256_t& hashBase,
+                                                         const uint64_t nExecutionTimestamp = 0);
 
     };
 }

--- a/src/TAO/Operation/execute.cpp
+++ b/src/TAO/Operation/execute.cpp
@@ -110,8 +110,8 @@ namespace TAO::Operation
                     if(!Validate::Verify(contract, condition, nCost))
                         return false;
 
-                    /* Commit the validation to disk. */
-                    if(!Validate::Commit(contract, hashTx, nContract, contract.Caller(), nFlags))
+                    /* Commit the validation to disk with execution transaction hash. */
+                    if(!Validate::Commit(contract, hashTx, nContract, contract.Caller(), contract.Hash(), nFlags))
                         return false;
 
                     /* Get next OP. */

--- a/src/TAO/Operation/include/validate.h
+++ b/src/TAO/Operation/include/validate.h
@@ -53,12 +53,14 @@ namespace TAO
              *  @param[in] hashTx The transaction-id being claimed.
              *  @param[in] nContract The contract output being claimed.
              *  @param[in] hashCaller The contract caller.
+             *  @param[in] hashExecution The transaction hash of the execution.
              *  @param[in] nFlags Flags to the LLD instance.
              *
              *  @return true if successful.
              *
              **/
-            bool Commit(const Contract& contract, const uint512_t& hashTx, const uint32_t nContract, const uint256_t& hashCaller, const uint8_t nFlags);
+            bool Commit(const Contract& contract, const uint512_t& hashTx, const uint32_t nContract,
+                        const uint256_t& hashCaller, const uint512_t& hashExecution, const uint8_t nFlags);
 
 
             /** Verify

--- a/src/TAO/Operation/validate.cpp
+++ b/src/TAO/Operation/validate.cpp
@@ -31,7 +31,8 @@ namespace TAO
     {
 
          /* Commit validation proofs. **/
-        bool Validate::Commit(const Contract& contract, const uint512_t& hashTx, const uint32_t nContract, const uint256_t& hashCaller, const uint8_t nFlags)
+        bool Validate::Commit(const Contract& contract, const uint512_t& hashTx, const uint32_t nContract,
+                              const uint256_t& hashCaller, const uint512_t& hashExecution, const uint8_t nFlags)
         {
             /* Check for disk write to add indexes. */
             if(nFlags == TAO::Ledger::FLAGS::BLOCK && config::fIndexProofs.load())
@@ -45,8 +46,8 @@ namespace TAO
             if(LLD::Contract->HasContract(std::make_pair(hashTx, nContract), nFlags))
                 return debug::error(FUNCTION, "OP::VALIDATE: cannot validate when already fulfilled");
 
-            /* Write the contract caller. */
-            if(!LLD::Contract->WriteContract(std::make_pair(hashTx, nContract), hashCaller, nFlags))
+            /* Write the contract caller and execution hash. */
+            if(!LLD::Contract->WriteContract(std::make_pair(hashTx, nContract), hashCaller, hashExecution, nFlags))
                 return debug::error(FUNCTION, "OP::VALIDATE: failed to write contract caller to disk");
 
             return true;


### PR DESCRIPTION
Suggestion for fix to issue 192: https://github.com/Nexusoft/LLL-TAO/issues/192 (market/list/executed/timestamp seem to be inherited from order creation time, not execution time).

See commits for detailed explanation where transaction hash is added. Please validate if this inclusion fits the "bigger picture", this fix was only done with this specific issue in mind.

Feel free to edit or decline.